### PR TITLE
Explore Hibernate DataStore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.6.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
@@ -17,15 +17,30 @@
  */
 package com.clueride.domain.account.member;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 /**
- * TODO: Description.
+ * Implementation of {@link MemberService}.
  */
 public class MemberServiceImpl implements MemberService {
+    private final MemberStore memberStore;
+
+    @Inject
+    public MemberServiceImpl(MemberStore memberStore) {
+        this.memberStore = memberStore;
+    }
+
     @Override
     public List<Member> getAllMembers() {
-        return Collections.EMPTY_LIST;
+        List<Member.Builder> builders = memberStore.getAllMembers();
+        List<Member> members = new ArrayList<>();
+        for (Member.Builder builder : builders) {
+            members.add(builder.build());
+        }
+        return members;
     }
+
 }

--- a/src/main/java/com/clueride/domain/account/member/MemberStore.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStore.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 6/25/16.
+ */
+package com.clueride.domain.account.member;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.mail.internet.InternetAddress;
+
+/**
+ * Persistence interface for {@link Member} instances.
+ */
+public interface MemberStore {
+    /**
+     * Accepts fully-constructed {@link Member} to the store and returns the ID.
+     * @param member - instance to be persisted.
+     * @return Unique Integer ID for the new Member.
+     * @throws IOException if trouble persisting.
+     */
+    Integer addNew(Member member) throws IOException;
+
+    /**
+     * Retrieves the {@link Member} instance matching the ID.
+     * @param id - Unique ID for the Member.
+     * @return Unique matching instance.
+     */
+    Member getMemberById(Integer id);
+
+    /**
+     * Retrieves the list of {@link Member} whose name matches.
+     * Note that names are not checked for uniqueness; this won't be the PK field
+     * for the record.
+     * @param name - String account name for the Member.
+     * @return All matching instances.
+     */
+    List<Member> getMemberByName(String name);
+
+    /**
+     * Retrieves the {@link Member} instance matching the emailAddress.
+     * @param emailAddress - InternetAddress for the member.
+     * @return Unique matching instance.
+     */
+    Member getMemberByEmail(InternetAddress emailAddress);
+
+    void update(Member member);
+
+    /**
+     * Returns the entire list of members contained within the store.
+     * TODO: This won't be sustainable once we have a significant number of members, but it's sufficient for testing.
+     * @return List of the Members currently defined.
+     */
+    List<Member.Builder> getAllMembers();
+
+}

--- a/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/13/17.
+ */
+package com.clueride.domain.account.member;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.mail.internet.InternetAddress;
+import javax.persistence.EntityManager;
+
+/**
+ * JPA Implementation of the MemberStore (DAO) interface.
+ */
+@ApplicationScoped
+public class MemberStoreJpa implements MemberStore {
+    @Inject
+    private EntityManager entityManager;
+
+    @Override
+    public Integer addNew(Member member) throws IOException {
+        entityManager.persist(Member.Builder.from(member));
+        return member.getId();
+    }
+
+    @Override
+    public Member getMemberById(Integer id) {
+        Member.Builder memberBuilder = entityManager.find(Member.Builder.class, id);
+        return memberBuilder.build();
+    }
+
+    @Override
+    public List<Member> getMemberByName(String name) {
+        return null;
+    }
+
+    @Override
+    public Member getMemberByEmail(InternetAddress emailAddress) {
+        Member.Builder memberBuilder;
+            memberBuilder = entityManager
+                    .createQuery(
+                            "select m from member m where m.emailAddress = :emailAddress",
+                            Member.Builder.class
+                    )
+                    .setParameter("emailAddress", emailAddress.toString())
+                    .getSingleResult();
+
+        return memberBuilder.build();
+    }
+
+    @Override
+    public void update(Member member) {
+
+    }
+
+    @Override
+    public List<Member.Builder> getAllMembers() {
+        return entityManager.createQuery("SELECT m FROM member m").getResultList();
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -23,10 +23,10 @@
    <persistence-unit name="primary">
       <!-- If you are running in a production environment, add a managed 
          data source, the example data source is just for proofs of concept! -->
-      <jta-data-source>java:jboss/datasources/serverDS</jta-data-source>
+      <jta-data-source>java:/DS/PostgreSQL</jta-data-source>
       <properties>
          <!-- Properties for Hibernate -->
-         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.hbm2ddl.auto" value="update" />
          <property name="hibernate.show_sql" value="false" />
       </properties>
    </persistence-unit>


### PR DESCRIPTION
- Adds MemberStore and JPA implementation.
- Updates persistence.xml to use container's JNDI Data Source.
- Turns off auto-gen of tables (changed to update for now).
- Brings in Mail API to support one field of the Member class.