### PR TITLE
Logging with Log4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
             <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
-        /* Required by cdi-unit: */
+        <!-- Required by cdi-unit: -->
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se</artifactId>
@@ -223,8 +223,17 @@
             <version>1.4.4</version>
             <scope>test</scope>
         </dependency>
-
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.8.0-beta2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.8.0-beta2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=ERROR,stdout
+log4j.logger.com.endeca=INFO
+# Logger for crawl metrics
+log4j.logger.com.endeca.itl.web.metrics=INFO
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%p\t%d{ISO8601}\t%r\t%c\t[%t]\t%m%n
+
+log4j.logger.com.jglue.cdiunit=DEBUG


### PR DESCRIPTION
- Adds SLF4J libraries that Weld complained about.
- Provides log4j.properties -- turns off all logging from Weld.