### PR TITLE
CA-391 Check @Secured for session validation

### DIFF
--- a/src/main/java/com/clueride/auth/Secured.java
+++ b/src/main/java/com/clueride/auth/Secured.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/25/17.
+ * Brought to this project by jett on 11/21/18.
+ */
+package com.clueride.auth;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation indicating protected REST API endpoints.
+ */
+@NameBinding
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface Secured {
+}

--- a/src/main/java/com/clueride/auth/access/AccessTokenService.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/13/18.
+ */
+package com.clueride.auth.access;
+
+/**
+ * Describes the features provided for Access Tokens.
+ */
+public interface AccessTokenService {
+    /**
+     * Given an Access Token as provided by the client, return
+     * the Identity attributes matching that token.
+     *
+     * This will perform the following services on a token before granting access:
+     * <ol>
+     *     <li>Check to see if it is in Cache. If so, it is already validated.</li>
+     *     <li>Request the Identity Server to tell us whether the access token matches a known user and cache those
+     *     results if they are found.</li>
+     *     <li>Provide a rejection if the access token is invalid, can't be found, or is otherwise rejected.</li>
+     * </ol>
+     * @param token token as provided by the client requesting access.
+     * @return ClueRideIdentity containing identifying details for this user -- particularly the email address.
+     */
+    // TODO: Worry about what gets returned later
+//    ClueRideIdentity getIdentity(String token);
+
+    /**
+     * Convenience method for working with the more complete AccessToken instance.
+     *
+     * @param accessToken instance of type {@link AccessToken}.
+     * @return ClueRideIdentity containing identifying details for this user -- particularly the email address.
+     */
+    // TODO: Worry about what gets returned later
+//    ClueRideIdentity getIdentity(AccessToken accessToken) throws ExecutionException;
+
+    /**
+     * Given an Access Token as provided by the client, return the Principal string matching that token (generally,
+     * the email address).
+     *
+     * Values may be cached.
+     *
+     * @param token Raw String as provided by the Authorization Header.
+     * @return String representing the principal (unique email address identifying the user).
+     */
+    String getPrincipalString(String token);
+
+    /**
+     * Clears the cache of all data.
+     */
+    void emptyCache();
+
+}

--- a/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
@@ -13,34 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 11/12/18.
+ * Created by jett on 11/21/18.
  */
-package com.clueride.domain.account.member;
+package com.clueride.auth.access;
 
-import java.util.List;
-
-import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
-import com.clueride.auth.Secured;
+import org.slf4j.Logger;
 
 /**
- * REST API for Members.
+ * TODO: Temporary implementation for proof-of-concept.
  */
-@Path("/member")
-@RequestScoped
-public class MemberWebService {
-    @Inject
-    private MemberService memberService;
+public class AccessTokenServiceImpl implements AccessTokenService {
 
-    @GET
-    @Secured
-    @Produces(MediaType.APPLICATION_JSON)
-    public List<Member> getAllMembers() {
-        return memberService.getAllMembers();
+    @Inject
+    private Logger LOGGER;
+
+    @Override
+    public String getPrincipalString(String token) {
+        LOGGER.debug("Looking up Principal by Access Token");
+        return "Placeholder";
     }
+
+    @Override
+    public void emptyCache() {
+        LOGGER.debug("Clearing the Access Token Cache");
+    }
+
 }

--- a/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/25/17.
+ */
+package com.clueride.auth.filter;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+
+import com.clueride.auth.Secured;
+import com.clueride.auth.access.AccessTokenService;
+
+/**
+ * Allows picking up Authorization headers and extracting the Principal.
+ *
+ * This is also responsible for inserting the Principal into the Session.
+ * The @Secured annotation on Jersey endpoints is what triggers this to be called.
+ */
+@Provider
+@Secured
+@Priority(Priorities.AUTHENTICATION)
+public class AuthenticationFilter implements ContainerRequestFilter {
+    @Inject
+    private Logger LOGGER;
+
+    // TODO: Maybe provided by CDI?
+//    private final Provider<SessionPrincipal> sessionPrincipalProvider;
+    // TODO: Perhaps a better place for this? What functionality does this provide?
+//    private final PrincipalService principalService;
+    @Inject
+    private AccessTokenService accessTokenService;
+
+    private final String testToken;
+    private final String testAccount;
+
+    /**
+     * Using the @Provider annotation is forcing this to use the no-parameter constructor.
+     */
+    @Inject
+    public AuthenticationFilter(
+//            Provider<SessionPrincipal> sessionPrincipalProvider,
+//            PrincipalService principalService,
+    ) {
+        super();
+
+        /* Injected components are not available when this is constructed. */
+//        LOGGER.debug("Instantiating");
+
+        // TODO: I don't know where this ends up.
+        System.out.println("Instantiating and maybe not logging?");
+//        this.sessionPrincipalProvider = sessionPrincipalProvider;
+//        this.principalService = principalService;
+
+        // TODO: Add a ConfigService.
+        /* From config */
+//        this.testToken = configService.getTestToken();
+        this.testToken = "Change this to your secret test token";
+//        this.testAccount = configService.getTestAccount();
+        this.testAccount = "bike.angel.atl@gmail.com";
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (requestContext.getMethod().equals(HttpMethod.OPTIONS)) {
+            /* Free pass for OPTIONS requests? */
+            LOGGER.debug("Allowing OPTIONS request");
+            return;
+        }
+        // Get the HTTP Authorization header from the request
+        String authorizationHeader =
+                requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        // Check if the HTTP Authorization header is present and formatted correctly
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            LOGGER.error("Authorization Header missing or malformed");
+            requestContext.abortWith(
+                    Response.status(Response.Status.UNAUTHORIZED).build());
+        }
+
+        // Extract the token from the HTTP Authorization header
+        String token = authorizationHeader.substring("Bearer".length()).trim();
+
+        String candidatePrincipalName = "Not logged in";
+        if (token.equals(testToken)) {
+            candidatePrincipalName = testAccount;
+        } else {
+            candidatePrincipalName = accessTokenService.getPrincipalString(token);
+        }
+
+        final String principalName = candidatePrincipalName;
+        LOGGER.info("Logged in as " + principalName);
+
+        /* This one is used for Method Interceptors for Badge Capture. */
+//        setSessionPrincipal(principalName);
+
+        /* This one is used for Jersey Calls. */
+        setSecurityContextPrincipal(requestContext, principalName);
+    }
+
+    /** Add user to the Context for this invocation; used by JAX-RS & Jersey calls. */
+    private void setSecurityContextPrincipal(
+            ContainerRequestContext requestContext,
+            final String principalName
+    ) {
+        final SecurityContext currentSecurityContext = requestContext.getSecurityContext();
+        requestContext.setSecurityContext(new SecurityContext() {
+
+            @Override
+            public Principal getUserPrincipal() {
+
+                return new Principal() {
+
+                    @Override
+                    public String getName() {
+                        return principalName;
+                    }
+                };
+            }
+
+            @Override
+            public boolean isUserInRole(String role) {
+                return true;
+            }
+
+            @Override
+            public boolean isSecure() {
+                return currentSecurityContext.isSecure();
+            }
+
+            @Override
+            public String getAuthenticationScheme() {
+                return "Bearer";
+            }
+        });
+    }
+
+    /** Name the user's principal as the SessionPrincipal. */
+//    private void setSessionPrincipal(String principalName) {
+//        sessionPrincipalProvider.get().setSessionPrincipal(
+//                principalService.getPrincipalForEmailAddress(
+//                        principalName
+//                )
+//        );
+//    }
+
+}

--- a/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
@@ -24,10 +24,15 @@ import javax.inject.Inject;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
+import org.slf4j.Logger;
+
 /**
  * Implementation of {@link MemberService}.
  */
 public class MemberServiceImpl implements MemberService {
+    @Inject
+    private Logger LOGGER;
+
     private final MemberStore memberStore;
 
     @Inject
@@ -37,6 +42,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public List<Member> getAllMembers() {
+        LOGGER.debug("Requesting All Members");
         List<Member.Builder> builders = memberStore.getAllMembers();
         List<Member> members = new ArrayList<>();
         for (Member.Builder builder : builders) {
@@ -47,6 +53,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Member getMemberByEmail(String emailAddress) throws AddressException {
+        LOGGER.debug("Requesting Member by email " + emailAddress);
         InternetAddress email = new InternetAddress(emailAddress);
         Member.Builder builder = memberStore.getMemberByEmail(email);
         return builder.build();

--- a/src/main/java/com/clueride/util/Resources.java
+++ b/src/main/java/com/clueride/util/Resources.java
@@ -16,15 +16,16 @@
  */
 package com.clueride.util;
 
-import java.util.logging.Logger;
-
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans
+ * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans.
  * 
  * <p>
  * Example injection on a managed bean field:
@@ -43,6 +44,6 @@ public class Resources {
 
     @Produces
     public Logger produceLog(InjectionPoint injectionPoint) {
-        return Logger.getLogger(injectionPoint.getMember().getDeclaringClass().getName());
+        return LoggerFactory.getLogger(injectionPoint.getMember().getDeclaringClass().getName());
     }
 }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootLogger=ERROR,stdout
+log4j.logger.com.endeca=INFO
+# Logger for crawl metrics
+log4j.logger.com.endeca.itl.web.metrics=INFO
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+# This format matches what WildFly is using:
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
+
+log4j.logger.com.clueride=DEBUG


### PR DESCRIPTION
- Adds AuthenticationFilter which responds to each REST call by virtue
of extending ContainerRequestFilter.
- Adds @Secured qualifier annotation for protected REST resources.
- Adds annotation to the MemberWebService to protect it.
- Adds interface and empty implementation for the AccessTokenService
responsible for validating the AccessToken against the 3rd-party auth
provider.

NOTE: There were some interesting NPEs until I was able to setup a "bean-style"
constructor; not able to use constructor-based injection for the AuthenticationFilter.
Further, none of the injected services are available at the time of construction.
Logging was a notable service.

Logging is also settling out within this commit:
- Log4j.properties as part of src/main/resources.
- Changed JUL over to SLF4J when generating the Logger resource for injection.
- Earlier commit placed the dependencies in the pom.xml.