### PR TITLE
CA-392 Configuration under WildFly: TypeSafe Config or other choices?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,15 @@
             <artifactId>javax.mail-api</artifactId>
             <version>1.6.0</version>
         </dependency>
+
+        <!-- Type Safe Config -->
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+
+        <!-- Support for CDI Unit Testing -->
         <dependency>
             <groupId>org.jglue.cdi-unit</groupId>
             <artifactId>cdi-unit</artifactId>

--- a/src/main/java/com/clueride/config/ConfigService.java
+++ b/src/main/java/com/clueride/config/ConfigService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/1/17.
+ */
+package com.clueride.config;
+
+import java.util.List;
+
+/**
+ * Defines interaction with configuration information.
+ */
+public interface ConfigService {
+    /**
+     * Returns configured value given the key information.
+     * @param key for the configured value.
+     * @return String matching the key.
+     */
+    String get(String key);
+
+    /**
+     * List of the valid Issuer Types.
+     * @return List of the valid Issuer Types.
+     */
+    List<String> getAuthIssuerTypes();
+
+    /** Returns list of the URL Strings identifying the Auth Issuers defined. */
+    List<String> getAuthIssuers();
+
+    /** Allows local override without placing secret in public code. */
+    String getAuthSecret();
+
+    /** Allows local override of a non-expiring Test Token for internal use. */
+    String getTestToken();
+
+    /** Account to be used during testing. */
+    String getTestAccount();
+
+}

--- a/src/main/java/com/clueride/config/ConfigServiceImpl.java
+++ b/src/main/java/com/clueride/config/ConfigServiceImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/1/17.
+ */
+package com.clueride.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * TypeSafe-backed implementation.
+ *
+ * Values can be overridden by defining JVM args (-D flag).
+ */
+public class ConfigServiceImpl implements ConfigService {
+    private static Config config = ConfigFactory.load();
+
+    @Override
+    public String get(String key) {
+        return config.getString(key);
+    }
+
+    @Override
+    public List<String> getAuthIssuerTypes() {
+        return config.getStringList("clueride.auth.issuerTypes");
+    }
+
+    @Override
+    public List<String> getAuthIssuers() {
+        List<String> authIssuers = new ArrayList<>();
+        List<String> issuerTypes = getAuthIssuerTypes();
+
+        for (String issuerType : issuerTypes) {
+            authIssuers.add(get("clueride.auth." + issuerType + ".url"));
+        }
+        return authIssuers;
+    }
+
+    @Override
+    public String getAuthSecret() {
+        return config.getString("clueride.auth.secret");
+    }
+
+    @Override
+    public String getTestToken() {
+        return get("clueride.test.token");
+    }
+
+    @Override
+    public String getTestAccount() {
+        return get("clueride.test.account");
+    }
+
+}

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,11 +1,14 @@
-log4j.rootLogger=ERROR,stdout
-log4j.logger.com.endeca=INFO
-# Logger for crawl metrics
-log4j.logger.com.endeca.itl.web.metrics=INFO
+log4j.rootLogger=ERROR, stdout
+log4j.logger.com.clueride=DEBUG, APP_LOG
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # This format matches what WildFly is using:
 log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
 
-log4j.logger.com.clueride=DEBUG
+log4j.appender.APP_LOG=org.apache.log4j.FileAppender
+log4j.appender.APP_LOG.File=clueride_app.log
+log4j.appender.APP_LOG.layout=org.apache.log4j.PatternLayout
+# This format matches what WildFly is using:
+log4j.appender.APP_LOG.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
+

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,30 @@
+clueride {
+
+    auth {
+        secret = Replace with the Auth0 secret
+        issuerTypes = [
+            # Represents Google, Facebook
+            Social,
+
+            # Represents sending and email or text to confirm identity
+            Passwordless
+        ]
+
+        # particulars for the Social Issuer
+        Social {
+            url = "https://clueride-social.auth0.com/"
+        }
+
+        # particulars for the Passwordless Issuer
+        Passwordless {
+            url = "https://clueride.auth0.com/"
+        }
+
+    }
+
+    test {
+        token = "Change this to your secret test token"
+        account = "your.test.account@yourdomain.com"
+    }
+
+}


### PR DESCRIPTION
- Adds TypeSafe Config to pom.xml.
- Adds Service and implementation for Config.
- Adds reference.conf from previous incarcation of this app.

Also provides for file logger for the application.

NOTE: There's not a lot of Java EE 7 specific configuration support;
TypeSafe Config addresses the issues which were discussed.