### PR TITLE
CA-393 Complete connection to Auth0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,38 @@
             <version>1.8.0-beta2</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- App Dependencies -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-osgi-bundle</artifactId>
+            <version>2.0.0.Alpha3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/clueride/RecordNotFoundException.java
+++ b/src/main/java/com/clueride/RecordNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/2/17.
+ */
+package com.clueride;
+
+/**
+ * Indicates the record requested is not available.
+ */
+public class RecordNotFoundException extends RuntimeException {
+
+    /**
+     * No arg constructor.
+     */
+    public RecordNotFoundException() {
+        super();
+    }
+
+    /**
+     * Single arg constructor.
+     * @param s logged along with exception.
+     */
+    public RecordNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/clueride/auth/AuthenticationConnection.java
+++ b/src/main/java/com/clueride/auth/AuthenticationConnection.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/18/18.
+ */
+package com.clueride.auth;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * How we connect to the Auth0 Identity Provider.
+ *
+ * Hides the details behind providing an access token
+ * and receiving the matching response JSON from Auth0.
+ *
+ * Wraps the URL, HttpsConnection, and InputStream for ease of mocking.
+ */
+public interface AuthenticationConnection {
+
+    /**
+     * Perform the connection to the given URL for Auth0 along with
+     * the access token matching the client whose identity we want.
+     *
+     * @param auth0Url One of the domains under which the user can authenticate.
+     * @param accessToken opaque token provided by Auth0 to the client for
+     *                    use in accessing resources.
+     * @return int response code -- 200 or 401 generally.
+     */
+    int makeRequest(URL auth0Url, String accessToken) throws IOException;
+
+    /**
+     * Given an access token provided by the client, return the matching
+     * JSON Response that holds the Client's identity.
+     *
+     * @return String containing the raw JSON response.
+     */
+    String getJsonResponse();
+
+    /**
+     * Provides the response code back from the request.
+     * @return int response code -- 200 or 401 generally.
+     */
+    int getResponseCode();
+
+    /**
+     * Provides the response message back from the request.
+     * @return String response message -- OK or Unauthorized.
+     */
+    String getResponseMessage();
+
+}

--- a/src/main/java/com/clueride/auth/AuthenticationConnectionAuth0.java
+++ b/src/main/java/com/clueride/auth/AuthenticationConnectionAuth0.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/18/18.
+ */
+package com.clueride.auth;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import javax.inject.Inject;
+import javax.net.ssl.HttpsURLConnection;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+
+/**
+ * Implementation of {@link AuthenticationConnection}.
+ */
+public class AuthenticationConnectionAuth0 implements AuthenticationConnection {
+    @Inject
+    private Logger LOGGER;
+
+    private String jsonResponse = null;
+    private int responseCode = 0;
+    private String responseMessage = null;
+
+    @Override
+    public int makeRequest(URL auth0Url, String accessToken) throws IOException {
+
+        /* Open Connection */
+        HttpsURLConnection connection = (HttpsURLConnection) auth0Url.openConnection();
+
+        /* Provide 'credentials' */
+        connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+        /* Retrieve response */
+        responseCode = connection.getResponseCode();
+        responseMessage = connection.getResponseMessage();
+        if (responseCode == 200) {
+            InputStream inputStr = connection.getInputStream();
+            String encoding = connection.getContentEncoding() == null ? "UTF-8"
+                    : connection.getContentEncoding();
+            jsonResponse = IOUtils.toString(inputStr, encoding);
+            LOGGER.debug(String.format("Raw JSON Response:\n%s", jsonResponse));
+        } else {
+            LOGGER.error(String.format(
+                    "Unable to read response: %d %s",
+                    responseCode,
+                    responseMessage)
+            );
+        }
+        return responseCode;
+    }
+
+    @Override
+    public String getJsonResponse() {
+        return jsonResponse;
+    }
+
+    @Override
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    @Override
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+
+}

--- a/src/main/java/com/clueride/auth/access/AccessToken.java
+++ b/src/main/java/com/clueride/auth/access/AccessToken.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/13/18.
+ */
+package com.clueride.auth.access;
+
+/**
+ * Holds the details about an Access Token.
+ *
+ * This starts with a String representation that can be parsed into the specific
+ * attributes of what that token represents.
+ */
+public class AccessToken {
+    private final String token;
+
+    private AccessToken(Builder builder) {
+        this.token = builder.getToken();
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public static class Builder {
+        public AccessToken build() {
+            return new AccessToken(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public Builder withToken(String token) {
+            this.token = token;
+            return this;
+        }
+
+        private String token;
+    }
+
+}

--- a/src/main/java/com/clueride/auth/access/AccessTokenService.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenService.java
@@ -17,6 +17,10 @@
  */
 package com.clueride.auth.access;
 
+import java.util.concurrent.ExecutionException;
+
+import com.clueride.auth.identity.ClueRideIdentity;
+
 /**
  * Describes the features provided for Access Tokens.
  */
@@ -35,8 +39,7 @@ public interface AccessTokenService {
      * @param token token as provided by the client requesting access.
      * @return ClueRideIdentity containing identifying details for this user -- particularly the email address.
      */
-    // TODO: Worry about what gets returned later
-//    ClueRideIdentity getIdentity(String token);
+    ClueRideIdentity getIdentity(String token);
 
     /**
      * Convenience method for working with the more complete AccessToken instance.
@@ -44,8 +47,7 @@ public interface AccessTokenService {
      * @param accessToken instance of type {@link AccessToken}.
      * @return ClueRideIdentity containing identifying details for this user -- particularly the email address.
      */
-    // TODO: Worry about what gets returned later
-//    ClueRideIdentity getIdentity(AccessToken accessToken) throws ExecutionException;
+    ClueRideIdentity getIdentity(AccessToken accessToken) throws ExecutionException;
 
     /**
      * Given an Access Token as provided by the client, return the Principal string matching that token (generally,

--- a/src/main/java/com/clueride/auth/identity/ClueRideIdentity.java
+++ b/src/main/java/com/clueride/auth/identity/ClueRideIdentity.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/13/18.
+ */
+package com.clueride.auth.identity;
+
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+import javax.annotation.concurrent.Immutable;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Attributes for a given actor as provided by the Identity Service.
+ *
+ * We may want to wrap my Member class in this.
+ *
+ * This is sample JSON returned from Auth0:
+ * {
+ *   "sub": "google-oauth2|{some number}",
+ *   "given_name": "Clue",
+ *   "family_name": "Ride",
+ *   "nickname": "clueride",
+ *   "name": "Clue Ride",
+ *   "picture": "{image URL}",
+ *   "gender": "male",
+ *   "locale": "en",
+ *   "updated_at": "2018-10-16T02:16:25.716Z",
+ *   "email": "clueride@gmail.com",
+ *   "email_verified": true
+ * }
+ */
+@Immutable
+public class ClueRideIdentity {
+    private final String sub;
+    private final Optional<String> givenName;
+    private final Optional<String> familyName;
+    private final String displayName;
+    private final String nickName;
+    private final URL pictureUrl;
+    private final Optional<String> gender;
+    private final String locale;
+    private final Date updatedAt;
+    private final InternetAddress email;
+    private final Boolean emailVerified;
+
+    public ClueRideIdentity(Builder builder) throws MalformedURLException, ParseException, AddressException {
+        this.sub = requireNonNull(builder.getSub(), "sub is required");
+        this.givenName = requireNonNull(builder.getGivenName(), "given name expects an Optional");
+        this.familyName = requireNonNull(builder.getFamilyName(), "family name expects an Optional");
+        this.nickName = requireNonNull(builder.getNickName(), "nickname is required");
+        this.displayName = requireNonNull(builder.getDisplayName(), "display name is required");
+        this.pictureUrl = builder.getPictureUrl();
+        this.gender = builder.getGender();
+        this.locale = builder.getLocale();
+        this.updatedAt = builder.getUpdatedAt();
+        this.email = builder.getEmail();
+        this.emailVerified = builder.getEmailVerified();
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public Optional<String> getGivenName() {
+        return givenName;
+    }
+
+    public Optional<String> getFamilyName() {
+        return familyName;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public URL getPictureUrl() {
+        return pictureUrl;
+    }
+
+    public Optional<String> getGender() {
+        return gender;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public InternetAddress getEmail() {
+        return email;
+    }
+
+    public Boolean getEmailVerified() {
+        return emailVerified;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public static class Builder {
+        private String sub;
+        private String givenName;
+        private String familyName;
+        private String nickName;
+        private String displayName;
+        private String pictureUrlString;
+        private String gender;
+        private String locale;
+        private String emailString;
+        private Boolean emailVerified;
+        @Transient
+        private URL pictureUrl;
+        private Date updatedAt;
+        private InternetAddress email;
+
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public ClueRideIdentity build() throws MalformedURLException, ParseException, AddressException {
+            return new ClueRideIdentity(this);
+        }
+
+        public String getSub() {
+            return sub;
+        }
+
+        public Builder withSub(String sub) {
+            this.sub = sub;
+            return this;
+        }
+
+        public Optional<String> getGivenName() {
+            return Optional.fromNullable(givenName);
+        }
+
+        @JsonProperty("given_name")
+        public Builder withGivenName(String givenName) {
+            this.givenName = givenName;
+            return this;
+        }
+
+        public Optional<String> getFamilyName() {
+            return Optional.fromNullable(familyName);
+        }
+
+        @JsonProperty("family_name")
+        public Builder withFamilyName(String familyName) {
+            this.familyName = familyName;
+            return this;
+        }
+
+        public String getNickName() {
+            return nickName;
+        }
+
+        @JsonProperty("nickname")
+        public Builder withNickName(String nickName) {
+            this.nickName = nickName;
+            return this;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @JsonProperty("name")
+        public Builder withDisplayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public String getPictureUrlString() {
+            return pictureUrlString;
+        }
+
+        public URL getPictureUrl() throws MalformedURLException {
+            pictureUrl = new URL(pictureUrlString);
+            return pictureUrl;
+        }
+
+        @JsonProperty("picture")
+        public Builder withPictureUrl(String pictureUrl) {
+            this.pictureUrlString = pictureUrl;
+            return this;
+        }
+
+        public Optional<String> getGender() {
+            return Optional.fromNullable(gender);
+        }
+
+        public Builder withGender(String gender) {
+            this.gender = gender;
+            return this;
+        }
+
+        public String getLocale() {
+            return locale;
+        }
+
+        public Builder withLocale(String locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public Date getUpdatedAt() throws ParseException {
+            return updatedAt;
+        }
+
+        @JsonProperty("updated_at")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+        public Builder withUpdatedAt(Date updatedAt) {
+            this.updatedAt= updatedAt;
+            return this;
+        }
+
+        public String getEmailString() {
+            return emailString;
+        }
+
+        public InternetAddress getEmail() throws AddressException {
+            email = new InternetAddress(emailString);
+            return email;
+        }
+
+        @JsonProperty("email")
+        public Builder withEmailString(String emailString) {
+            this.emailString = emailString;
+            return this;
+        }
+
+        public Boolean getEmailVerified() {
+            return emailVerified;
+        }
+
+        @JsonProperty("email_verified")
+        public Builder withEmailVerified(Boolean emailVerified) {
+            this.emailVerified = emailVerified;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return EqualsBuilder.reflectionEquals(this, obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+}

--- a/src/main/java/com/clueride/auth/identity/IdentityStore.java
+++ b/src/main/java/com/clueride/auth/identity/IdentityStore.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/13/18.
+ */
+package com.clueride.auth.identity;
+
+/**
+ * Describes how we obtain Identity instances.
+ *
+ * Caching would be performed outside of this service.
+ */
+public interface IdentityStore {
+    /**
+     * Given an Access Token provided by the client's authentication process,
+     * obtain the matching Identity from the Identity Provider.
+     *
+     * Returns Test Account if token matches a configurable account.
+     *
+     * @param accessToken String encoded such that Identity Provider recognizes it.
+     * @return ClueRideIdentity populated from the Identity Provider's response.
+     */
+    ClueRideIdentity getIdentity(String accessToken);
+
+}

--- a/src/main/java/com/clueride/auth/identity/IdentityStoreAuth0.java
+++ b/src/main/java/com/clueride/auth/identity/IdentityStoreAuth0.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/13/18.
+ */
+package com.clueride.auth.identity;
+
+import java.io.IOException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.mail.internet.AddressException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
+
+import com.clueride.auth.AuthenticationConnection;
+import com.clueride.config.ConfigService;
+import com.clueride.RecordNotFoundException;
+
+/**
+ * Implementation of Identity Store that is backed by Auth0 as the identity provider.
+ */
+public class IdentityStoreAuth0 implements IdentityStore {
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private final AuthenticationConnection authenticationConnection;
+    private final ConfigService configService;
+
+    @Inject
+    public IdentityStoreAuth0(
+            AuthenticationConnection authenticationConnection,
+            ConfigService configService
+    ) {
+        this.authenticationConnection = authenticationConnection;
+        this.configService = configService;
+    }
+
+    @Override
+    public ClueRideIdentity getIdentity(String accessToken) {
+        List<String> issuers = configService.getAuthIssuers();
+
+        /* Walk through the configured list of Issuers. */
+        for (String issuer : issuers) {
+            int responseCode = HttpStatus.SC_UNAUTHORIZED;
+
+            try {
+                /* Build URL for userinfo endpoint*/
+                URL identityProviderUrl = new URL(issuer +"userinfo");
+
+                /* Make Request and look at the response code. */
+                responseCode = authenticationConnection.makeRequest(
+                        identityProviderUrl,
+                        accessToken
+                );
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            if (HttpStatus.SC_OK == responseCode) {
+                String jsonResponse = authenticationConnection.getJsonResponse();
+                try {
+                    /* Parse response from Identity Provider. */
+                    return objectMapper.readValue(jsonResponse, ClueRideIdentity.Builder.class).build();
+                } catch (IOException | ParseException | AddressException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        /* No issuer was able to verify the Access Token. */
+        throw new RecordNotFoundException(accessToken);
+    }
+
+}


### PR DESCRIPTION
- Adds implementation for AccessToken Service turning opaque token into
ClueRide Identity from 3rd-party authentication service.
- Adds the definition of a ClueRideIdentity.
- Adds connection code for 3rd-party authentication service (Auth0).

This also brings in a number of libraries to support:
- @Immutable
- Optional<>
- Jackson JSON handling
- HttpClient code for conversation with 3rd-party Authentication service.