### PR TITLE
CA-396 Retrieve list of User from the BadgeOS system

### DIFF
--- a/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
@@ -21,16 +21,16 @@ import java.io.IOException;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 /**
  * JPA Implementation of the MemberStore (DAO) interface.
  */
 @ApplicationScoped
 public class MemberStoreJpa implements MemberStore {
-    @Inject
+    @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
 
     @Override

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipal.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipal.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/28/18.
+ */
+package com.clueride.domain.account.principal;
+
+import java.security.Principal;
+
+import javax.annotation.concurrent.Immutable;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Identifies a given user in the BadgeOS system including email address, Name and user ID within WordPress.
+ */
+@Immutable
+public class BadgeOsPrincipal implements Principal {
+    private Integer badgeOsUserId;
+    private String name;
+    private InternetAddress emailAddress;
+
+    private BadgeOsPrincipal(Builder builder) {
+        this.name = requireNonNull(builder.getName());
+        this.badgeOsUserId = requireNonNull(builder.getBadgeOsUserId());
+        this.emailAddress = requireNonNull(builder.getEmailAddress());
+    }
+
+    public Integer getBadgeOsUserId() {
+        return badgeOsUserId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public InternetAddress getEmailAddress() {
+        return emailAddress;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="badgeos_principal")
+    @Table(name="wp_users")
+    public static class Builder {
+        /**
+         * Builder for BadgeOsPrincipal.
+         */
+        @Id
+        private Integer id;
+
+        @Column(name="display_name")
+        private String name;
+
+        @Transient
+        private InternetAddress emailAddress;
+
+        @Column(name="user_email")
+        private String emailAddressString;
+
+        public BadgeOsPrincipal build() {
+            return new BadgeOsPrincipal(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public InternetAddress getEmailAddress() {
+            emailStringToInternetAddress(emailAddressString);
+            return this.emailAddress;
+        }
+
+        public Builder withEmailAddress(InternetAddress emailAddress) {
+            this.emailAddressString = emailAddress.toString();
+            this.emailAddress = emailAddress;
+            return this;
+        }
+
+        public Builder withEmailAddressString(String emailAddressString) {
+            this.emailAddressString = emailAddressString;
+            emailStringToInternetAddress(emailAddressString);
+            return this;
+        }
+
+        private void emailStringToInternetAddress(String emailAddressString) {
+            try {
+                this.emailAddress = new InternetAddress(emailAddressString);
+            } catch (AddressException e) {
+                this.emailAddress = null;
+                e.printStackTrace();
+            }
+        }
+
+        public Integer getBadgeOsUserId() {
+            return id;
+        }
+
+        public Builder withId(Integer badgeOsUserId) {
+            return withBadgeOsUserId(badgeOsUserId);
+        }
+
+        public Builder withBadgeOsUserId(Integer badgeOsUserId) {
+            this.id = badgeOsUserId;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return EqualsBuilder.reflectionEquals(this, obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+
+    }
+
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalFilter.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/29/18.
+ */
+package com.clueride.domain.account.principal;
+
+/**
+ * Represents criteria by which to filter the Principals held within BadgeOS.
+ */
+public class BadgeOsPrincipalFilter {
+    FilterType filterType = FilterType.NO_CRITERIA;
+
+    /* TODO: expect this to expand as business needs coalesce. */
+
+    public enum FilterType {
+        NO_CRITERIA,
+        SINGLE_CRITERIA,
+        MULTIPLE_CRITERIA
+    }
+
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalService.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/28/18.
+ */
+package com.clueride.domain.account.principal;
+
+import java.util.List;
+
+import javax.mail.internet.InternetAddress;
+
+/**
+ * Given an Email Address, provides the matching principal from BadgeOS.
+ */
+public interface BadgeOsPrincipalService {
+    /**
+     * Given an Email Address, provides the matching principal from BadgeOS.
+     * @param emailAddress to be matched within BadgeOS.
+     * @return Fully-populated BadgeOsPrincipal.
+     */
+    BadgeOsPrincipal getBadgeOsPrincipal(InternetAddress emailAddress);
+
+    BadgeOsPrincipal getBadgeOsPrincipal(String emailAddress);
+
+    List<BadgeOsPrincipal> getFilteredPrincipals(BadgeOsPrincipalFilter filter);
+
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/28/18.
+ */
+package com.clueride.domain.account.principal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+
+import org.slf4j.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation that simply maps between what is in BadgeOS for a given email address.
+ */
+public class BadgeOsPrincipalServiceImpl implements BadgeOsPrincipalService {
+    @Inject
+    private Logger LOGGER;
+
+    private final BadgeOsPrincipalStore badgeOsPrincipalStore;
+
+    @Inject
+    public BadgeOsPrincipalServiceImpl(
+            BadgeOsPrincipalStore badgeOsPrincipalStore
+    ) {
+        this.badgeOsPrincipalStore = badgeOsPrincipalStore;
+    }
+
+    @Override
+    public BadgeOsPrincipal getBadgeOsPrincipal(InternetAddress emailAddress) {
+        requireNonNull(emailAddress, "Email Address must be non-null");
+
+        return badgeOsPrincipalStore.getBadgeOsPrincipalForEmailAddress(
+                emailAddress
+        ).build();
+    }
+
+    @Override
+    public BadgeOsPrincipal getBadgeOsPrincipal(String emailAddress) {
+        requireNonNull(emailAddress);
+        LOGGER.info("Looking up Principal for " + emailAddress);
+
+        try {
+            InternetAddress internetAddress = new InternetAddress(emailAddress);
+            return getBadgeOsPrincipal(internetAddress);
+        } catch (AddressException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public List<BadgeOsPrincipal> getFilteredPrincipals(BadgeOsPrincipalFilter filter) {
+        List<BadgeOsPrincipal> principals = new ArrayList<>();
+        List<BadgeOsPrincipal.Builder> builders = badgeOsPrincipalStore.getAll();
+        for (BadgeOsPrincipal.Builder builder : builders) {
+            principals.add(builder.build());
+        }
+        return principals;
+    }
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStore.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStore.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/28/18.
+ */
+package com.clueride.domain.account.principal;
+
+import java.util.List;
+
+import javax.mail.internet.InternetAddress;
+
+/**
+ * How we retrieve BadgeOS Principals from the BadgeOS system.
+ */
+public interface BadgeOsPrincipalStore {
+
+    /**
+     * Retrieves the BadgeOsPrincipal for the given email address.
+     * @param emailAddress supplied by the user's credentials.
+     * @return Principal containing the User ID, Display Name, and the email address.
+     */
+    BadgeOsPrincipal.Builder getBadgeOsPrincipalForEmailAddress(InternetAddress emailAddress);
+
+    /**
+     * Retrieves the full set of Principals.
+     *
+     * @return List of all {@link BadgeOsPrincipal}.
+     */
+    List<BadgeOsPrincipal.Builder> getAll();
+
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/28/18.
+ */
+package com.clueride.domain.account.principal;
+
+import java.util.List;
+
+import javax.mail.internet.InternetAddress;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * JPA implementation of the Badge OS Principal Store.
+ */
+public class BadgeOsPrincipalStoreJpa implements BadgeOsPrincipalStore {
+    @PersistenceContext(unitName = "badgeOS")
+    private EntityManager entityManager;
+
+    @Override
+    public BadgeOsPrincipal.Builder getBadgeOsPrincipalForEmailAddress(InternetAddress emailAddress) {
+        requireNonNull(emailAddress);
+
+        BadgeOsPrincipal.Builder principalBuilder = BadgeOsPrincipal.Builder.builder();
+//        try {
+//            entityManager.getTransaction().begin();
+//
+//            principalBuilder = entityManager
+//                    .createQuery(
+//                            "from badgeos_principal p where p.emailAddressString = :emailAddress",
+//                            BadgeOsPrincipal.Builder.class
+//                    )
+//                    .setParameter("emailAddress", emailAddress.toString())
+//                    .getSingleResult();
+//            entityManager.getTransaction().commit();
+//        } catch (Exception e) {
+//            entityManager.getTransaction().rollback();
+//            throw e;
+//        }
+
+        return principalBuilder;
+    }
+
+    @Override
+    public List<BadgeOsPrincipal.Builder> getAll() {
+        return entityManager.createQuery("SELECT p FROM badgeos_principal p").getResultList();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalWebService.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalWebService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/29/18.
+ */
+package com.clueride.domain.account.principal;
+
+
+import java.util.List;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.clueride.auth.Secured;
+
+/**
+ * REST Endpoint for Principals.
+ */
+@Path("/user")
+@RequestScoped
+public class BadgeOsPrincipalWebService {
+    @Inject
+    private BadgeOsPrincipalService principalService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<BadgeOsPrincipal> getAllPrincipals() {
+        return principalService.getFilteredPrincipals(new BadgeOsPrincipalFilter());
+    }
+
+}

--- a/src/main/java/com/clueride/domain/badge/event/BadgeEventStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/event/BadgeEventStoreJpa.java
@@ -17,27 +17,15 @@
  */
 package com.clueride.domain.badge.event;
 
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
 import javax.persistence.EntityManager;
-
-//import com.clueride.infrastructure.db.ClueRide;
+import javax.persistence.PersistenceContext;
 
 /**
  * Implementation of Badge Event Store for JPA.
  */
 public class BadgeEventStoreJpa implements BadgeEventStore {
-
-    private final EntityManager entityManager;
-
-    @Inject
-    public BadgeEventStoreJpa(
-            @Nonnull
-//            @ClueRide
-                    EntityManager entityManager
-    ) {
-        this.entityManager = entityManager;
-    }
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
 
     @Override
     public Integer add(BadgeEvent.Builder badgeEventBuilder) {

--- a/src/main/java/com/clueride/util/Resources.java
+++ b/src/main/java/com/clueride/util/Resources.java
@@ -39,8 +39,12 @@ import org.slf4j.LoggerFactory;
 public class Resources {
 
     @Produces
-    @PersistenceContext
-    private EntityManager em;
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager emClueRide;
+
+    @Produces
+    @PersistenceContext(unitName = "badgeOS")
+    private EntityManager emWordPress;
 
     @Produces
     public Logger produceLog(InjectionPoint injectionPoint) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -20,7 +20,7 @@
    xsi:schemaLocation="
         http://xmlns.jcp.org/xml/ns/persistence
         http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
-   <persistence-unit name="primary">
+   <persistence-unit name="clueride">
       <!-- If you are running in a production environment, add a managed 
          data source, the example data source is just for proofs of concept! -->
       <jta-data-source>java:/DS/PostgreSQL</jta-data-source>
@@ -29,5 +29,8 @@
          <property name="hibernate.hbm2ddl.auto" value="update" />
          <property name="hibernate.show_sql" value="false" />
       </properties>
+   </persistence-unit>
+   <persistence-unit name="badgeOS">
+      <jta-data-source>java:/DS/BadgeOS</jta-data-source>
    </persistence-unit>
 </persistence>


### PR DESCRIPTION
- Adds BadgeOsPrincipal suite of web service, service, store, entity and a filter for searching users.
- Updates persistence.xml and Resources to handle two datasources and entities (PersistenceContext).
- Updates Store implementations to distinguish which EntityManagers it will use.

Tested using Postman to retrieve list of BadgeOS user/principals.