### PR TITLE
CA-404 REST API for Registration Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
             <artifactId>aopalliance</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
@@ -48,6 +48,8 @@ import com.clueride.domain.account.principal.PrincipalService;
  *
  * This is also responsible for inserting the Principal into the Session.
  * The @Secured annotation on Jersey endpoints is what triggers this to be called.
+ *
+ * TODO: Consider moving some of this logic over to the AccessState service.
  */
 @Provider
 @Secured
@@ -120,24 +122,19 @@ public class AuthenticationFilter implements ContainerRequestFilter {
      * matching ClueRideIdentity for use during testing.
      * @param token as configured.
      * @param candidatePrincipalName also as configured.
-     * @throws MalformedURLException not expected to occur since the URL is hardcoded here.
      */
     private void buildClueRideIdentity(String token, String candidatePrincipalName) throws MalformedURLException {
         ClueRideIdentity clueRideIdentity;
-        try {
-            clueRideIdentity = ClueRideIdentity.Builder.builder()
-                    .withSub("")
-                    .withDisplayName("Test Account")
-                    .withNickName("scarf")
-                    .withPictureUrl("https://clueride.com")
-                    .withLocale("en")
-                    .withUpdatedAt(new Date())
-                    .withEmailVerified(true)
-                    .withEmailString(candidatePrincipalName).build();
-            accessTokenService.addIdentity(token, clueRideIdentity);
-        } catch (ParseException | AddressException e) {
-            e.printStackTrace();
-        }
+        clueRideIdentity = ClueRideIdentity.Builder.builder()
+                .withSub("")
+                .withDisplayName("Test Account")
+                .withNickName("scarf")
+                .withPictureUrl("https://clueride.com")
+                .withLocale("en")
+                .withUpdatedAt(new Date())
+                .withEmailVerified(true)
+                .withEmailString(candidatePrincipalName).build();
+        accessTokenService.addIdentity(token, clueRideIdentity);
     }
 
 }

--- a/src/main/java/com/clueride/auth/identity/ClueRideIdentity.java
+++ b/src/main/java/com/clueride/auth/identity/ClueRideIdentity.java
@@ -71,7 +71,7 @@ public class ClueRideIdentity {
     private final InternetAddress email;
     private final Boolean emailVerified;
 
-    public ClueRideIdentity(Builder builder) throws MalformedURLException, ParseException, AddressException {
+    public ClueRideIdentity(Builder builder) {
         this.sub = requireNonNull(builder.getSub(), "sub is required");
         this.givenName = requireNonNull(builder.getGivenName(), "given name expects an Optional");
         this.familyName = requireNonNull(builder.getFamilyName(), "family name expects an Optional");
@@ -181,8 +181,12 @@ public class ClueRideIdentity {
                     ;
         }
 
-        public ClueRideIdentity build() throws MalformedURLException, ParseException, AddressException {
+        public ClueRideIdentity build() {
             return new ClueRideIdentity(this);
+        }
+
+        public void validate() throws MalformedURLException {
+            // TODO Would like better control over when we check the inputs; instead of during build().
         }
 
         public String getSub() {
@@ -238,14 +242,23 @@ public class ClueRideIdentity {
             return pictureUrlString;
         }
 
-        public URL getPictureUrl() throws MalformedURLException {
-            pictureUrl = new URL(pictureUrlString);
+        public URL getPictureUrl() {
+            try {
+                pictureUrl = new URL(pictureUrlString);
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+            }
             return pictureUrl;
         }
 
         @JsonProperty("picture")
         public Builder withPictureUrl(String pictureUrl) {
             this.pictureUrlString = pictureUrl;
+            return this;
+        }
+
+        public Builder withPictureUrl(URL pictureUrl) {
+            this.pictureUrl = pictureUrl;
             return this;
         }
 
@@ -267,7 +280,7 @@ public class ClueRideIdentity {
             return this;
         }
 
-        public Date getUpdatedAt() throws ParseException {
+        public Date getUpdatedAt() {
             return updatedAt;
         }
 
@@ -282,14 +295,23 @@ public class ClueRideIdentity {
             return emailString;
         }
 
-        public InternetAddress getEmail() throws AddressException {
-            email = new InternetAddress(emailString);
+        public InternetAddress getEmail() {
+            try {
+                email = new InternetAddress(emailString);
+            } catch (AddressException e) {
+                e.printStackTrace();
+            }
             return email;
         }
 
         @JsonProperty("email")
         public Builder withEmailString(String emailString) {
             this.emailString = emailString;
+            return this;
+        }
+
+        public Builder withEmail(InternetAddress emailAddress) {
+            this.email = emailAddress;
             return this;
         }
 

--- a/src/main/java/com/clueride/auth/identity/IdentityStoreAuth0.java
+++ b/src/main/java/com/clueride/auth/identity/IdentityStoreAuth0.java
@@ -20,11 +20,9 @@ package com.clueride.auth.identity;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
-import java.text.ParseException;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.mail.internet.AddressException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
@@ -86,7 +84,7 @@ public class IdentityStoreAuth0 implements IdentityStore {
                     );
                     LOGGER.info("Retrieved 3rd-party Identity for {}", builder.getEmailString());
                     return builder.build();
-                } catch (IOException | ParseException | AddressException e) {
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
             }

--- a/src/main/java/com/clueride/auth/state/AccessStateService.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 12/10/18.
+ */
+package com.clueride.auth.state;
+
+/**
+ * Supports AccessStateWebService REST API.
+ */
+public interface AccessStateService {
+    /**
+     * Performs a series of tests to assure that we recognize the device from which
+     * the request is being made.
+     * @param authHeader String, which could be empty or null, that is expected to represent
+     *                   the <em>Authorization</em> header for any request to the REST API.
+     * @return true if the device has been registered and the token may be used to conduct other
+     * calls to the REST API. If false, it could indicate a few things (each of which are logged):
+     * <ul>
+     *     <li>Is the header present and non-empty?</li>
+     *     <li>Does the value of the header contain the 'Bearer' string?</li>
+     *     <li>If it is a Test Token, does the matching account exist within the system?</li>
+     *     <li>If not a Test Token, does the 3rd-party Identity Provider recognize the token?</li>
+     *     <li>If no one recognizes the token, throw an exception?</li>
+     * </ul>
+     */
+    Boolean isRegistered(String authHeader);
+
+}

--- a/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 12/10/18.
+ */
+package com.clueride.auth.state;
+
+import javax.inject.Inject;
+import javax.mail.internet.InternetAddress;
+
+import org.slf4j.Logger;
+
+import com.clueride.RecordNotFoundException;
+import com.clueride.auth.access.AccessTokenService;
+import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.config.ConfigService;
+import com.clueride.domain.account.member.Member;
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.principal.BadgeOsPrincipal;
+import com.clueride.domain.account.principal.BadgeOsPrincipalService;
+
+/**
+ * Implementation of {@link AccessStateService}.
+ */
+public class AccessStateServiceImpl implements AccessStateService {
+    @Inject
+    private Logger LOGGER;
+
+    private final AccessTokenService accessTokenService;
+    private final ConfigService configService;
+    private final BadgeOsPrincipalService badgeOsPrincipalService;
+    private final MemberService memberService;
+
+    @Inject
+    public AccessStateServiceImpl(
+            AccessTokenService accessTokenService,
+            ConfigService configService,
+            BadgeOsPrincipalService badgeOsPrincipalService,
+            MemberService memberService
+    ) {
+        this.accessTokenService = accessTokenService;
+        this.configService = configService;
+        this.badgeOsPrincipalService = badgeOsPrincipalService;
+        this.memberService = memberService;
+    }
+
+    @Override
+    public Boolean isRegistered(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return false;
+        }
+        String token = authHeader.substring("Bearer".length()).trim();
+        if (accessTokenService.isSessionActive(token)) {
+            return true;
+        } else {
+            if (token.equals(configService.getTestToken())) {
+                LOGGER.info("Allowing Test Token");
+                return true;
+            }
+            try {
+                ClueRideIdentity clueRideIdentity = accessTokenService.getIdentity(token);
+                createOrUpdatePrincipal(clueRideIdentity);
+            } catch (RecordNotFoundException rnfe) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks for existence of Member and BadgeOsPrincipal and updates Member record if not present.
+     *
+     * At this time, we're only registering principals which are found in Badge OS, so an exception
+     * is thrown if no Badge OS principal matches the ClueRideIdentity account.
+     * @param clueRideIdentity from the Identity Provider.
+     */
+    private void createOrUpdatePrincipal(ClueRideIdentity clueRideIdentity) {
+
+        /* Find Badge OS record. */
+        InternetAddress emailAddress = clueRideIdentity.getEmail();
+        BadgeOsPrincipal badgeOsPrincipal = null;
+        try {
+            badgeOsPrincipal = badgeOsPrincipalService.getBadgeOsPrincipal(emailAddress);
+        } catch (RecordNotFoundException rnfe) {
+            /* Handle the same as null returned below. */
+        }
+
+        if (badgeOsPrincipal == null) {
+            LOGGER.warn("Unable to find {} in Badge OS", emailAddress.toString());
+            throw(new RecordNotFoundException());
+        }
+
+        // TODO: CA-405 connect new identities with updated records & test coverage.
+        /* Check to see if we have a Member Record. */
+        Member member = null;
+        try {
+            member = memberService.getMemberByEmail(emailAddress);
+        } catch (RecordNotFoundException rnfe) {
+            /* No existing Member record, let's create one from ClueRideIdentity. */
+            memberService.createNewMember(clueRideIdentity);
+        }
+
+    }
+}

--- a/src/main/java/com/clueride/auth/state/AccessStateWebService.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateWebService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 12/9/18.
+ */
+package com.clueride.auth.state;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpHeaders;
+
+/**
+ * REST API for certain operations on an AccessToken's state.
+ *
+ * This verifies that the AccessToken which is presented by the client can be used or needs to be refreshed.
+ *
+ * Obtaining an AccessToken is the responsibility of a 3rd-party identity provider.
+ */
+@Path("access/state")
+@RequestScoped
+public class AccessStateWebService {
+    @Inject
+    private AccessStateService accessStateService;
+
+    @Inject HttpServletRequest httpServletRequest;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Boolean getAccessTokenState() {
+        String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        return accessStateService.isRegistered(authHeader);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/account/member/Member.java
+++ b/src/main/java/com/clueride/domain/account/member/Member.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import com.clueride.auth.identity.ClueRideIdentity;
 import static java.util.Objects.requireNonNull;
 
 public class Member implements Serializable {
@@ -145,6 +146,16 @@ public class Member implements Serializable {
                     .withEmailAddress(member.emailAddress);
         }
 
+        public static Builder from(ClueRideIdentity clueRideIdentity) {
+            requireNonNull(clueRideIdentity);
+            return builder()
+                    .withFirstName(clueRideIdentity.getGivenName().get())
+                    .withLastName(clueRideIdentity.getFamilyName().get())
+                    .withEmailAddress(clueRideIdentity.getEmail().toString())
+                    .withDisplayName(clueRideIdentity.getDisplayName())
+                    ;
+        }
+
         public Integer getId() {
             return id;
         }
@@ -240,4 +251,5 @@ public class Member implements Serializable {
         }
 
     }
+
 }

--- a/src/main/java/com/clueride/domain/account/member/MemberService.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberService.java
@@ -20,6 +20,9 @@ package com.clueride.domain.account.member;
 import java.util.List;
 
 import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import com.clueride.auth.identity.ClueRideIdentity;
 
 /**
  * Provides business-layer services for Members and their Badges.
@@ -38,5 +41,19 @@ public interface MemberService {
      * @return Matching instance of Member.
      */
     Member getMemberByEmail(String emailAddress) throws AddressException;
+
+    /**
+     * Retrieve Member instances by Email Address (Principal).
+     * @param emailAddress InternetAddress representation of the Principal's email address.
+     * @return Matching instance of Member.
+     */
+    Member getMemberByEmail(InternetAddress emailAddress);
+
+    /**
+     * Creates a new Member record based on the ClueRideIdentity that comes from the Identity Provider.
+     * @param clueRideIdentity personal data provided by Identity Provider.
+     * @return Member instance built from ClueRideIdentity.
+     */
+    Member createNewMember(ClueRideIdentity clueRideIdentity);
 
 }

--- a/src/main/java/com/clueride/domain/account/member/MemberStore.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStore.java
@@ -17,7 +17,6 @@
  */
 package com.clueride.domain.account.member;
 
-import java.io.IOException;
 import java.util.List;
 
 import javax.mail.internet.InternetAddress;
@@ -27,12 +26,11 @@ import javax.mail.internet.InternetAddress;
  */
 public interface MemberStore {
     /**
-     * Accepts fully-constructed {@link Member} to the store and returns the ID.
-     * @param member - instance to be persisted.
-     * @return Unique Integer ID for the new Member.
-     * @throws IOException if trouble persisting.
+     * Accepts fully-populated {@link Member.Builder} to the store and returns the Member record with DB-assigned ID.
+     * @param memberBuilder - instance to be persisted.
+     * @return Same record as passed in with DB-assigned ID.
      */
-    Integer addNew(Member member) throws IOException;
+    Member.Builder addNew(Member.Builder memberBuilder);
 
     /**
      * Retrieves the {@link Member} instance matching the ID.

--- a/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
@@ -17,13 +17,19 @@
  */
 package com.clueride.domain.account.member;
 
-import java.io.IOException;
 import java.util.List;
 
+import javax.annotation.Resource;
 import javax.enterprise.context.ApplicationScoped;
 import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
 
 /**
  * JPA Implementation of the MemberStore (DAO) interface.
@@ -33,10 +39,20 @@ public class MemberStoreJpa implements MemberStore {
     @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
 
+    @Resource
+    private UserTransaction userTransaction;
+
     @Override
-    public Integer addNew(Member member) throws IOException {
-        entityManager.persist(Member.Builder.from(member));
-        return member.getId();
+    public Member.Builder addNew(Member.Builder memberBuilder) {
+        // TODO: CA-405
+        try {
+            userTransaction.begin();
+            entityManager.persist(memberBuilder);
+            userTransaction.commit();
+        } catch (NotSupportedException | SystemException | HeuristicMixedException | RollbackException | HeuristicRollbackException e) {
+            e.printStackTrace();
+        }
+        return memberBuilder;
     }
 
     @Override

--- a/src/test/java/com/clueride/auth/state/AccessStateServiceImplTest.java
+++ b/src/test/java/com/clueride/auth/state/AccessStateServiceImplTest.java
@@ -1,0 +1,192 @@
+package com.clueride.auth.state;/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 12/9/18.
+ */
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jglue.cdiunit.AdditionalClasses;
+import org.jglue.cdiunit.NgCdiRunner;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import com.clueride.RecordNotFoundException;
+import com.clueride.auth.access.AccessTokenService;
+import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.config.ConfigService;
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.principal.BadgeOsPrincipal;
+import com.clueride.domain.account.principal.BadgeOsPrincipalService;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Exercises the AccessStateServiceImplTest class.
+ */
+@AdditionalClasses({TestResources.class})
+public class AccessStateServiceImplTest extends NgCdiRunner {
+
+    @Produces
+    @Mock
+    Logger LOGGER;
+
+    private String TEST_TOKEN = "Test Token";
+    private String AUTH_HEADER_TEST = "Bearer " + TEST_TOKEN;
+    private String IDENTITY_PROVIDER_TOKEN = "1qaz2wsx";
+    private String AUTH_HEADER_IP = "Bearer " + IDENTITY_PROVIDER_TOKEN;
+
+    @Singleton
+    @Produces
+    @Mock
+    private AccessTokenService accessTokenService;
+
+    @Produces
+    @Mock
+    private BadgeOsPrincipalService badgeOsPrincipalService;
+
+    @Inject
+    private Instance<ClueRideIdentity> clueRideIdentityProvider;
+    private ClueRideIdentity mockClueRideIdentity;
+
+    @Inject
+    private Instance<BadgeOsPrincipal> badgeOsPrincipalProvider;
+    private BadgeOsPrincipal mockBadgeOsPrincipal;
+
+    @Produces
+    @Mock
+    private ConfigService configService;
+
+    @Produces
+    @Mock
+    private MemberService memberService;
+
+    @InjectMocks
+    private AccessStateServiceImpl toTest;
+
+    @BeforeSuite
+    /* Initializing the mocks once per suite avoids creating new instances of the mocks on each test run. */
+    public void suiteSetup() throws Exception {
+        initMocks(this);
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        assertNotNull(toTest);
+
+        /* Config service should always return this. */
+        when(configService.getTestToken()).thenReturn(TEST_TOKEN);
+
+        mockClueRideIdentity = clueRideIdentityProvider.get();
+        assertNotNull(mockClueRideIdentity);
+        mockBadgeOsPrincipal = badgeOsPrincipalProvider.get();
+        assertNotNull(mockBadgeOsPrincipal);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+    }
+
+    /** Should allow token that has already been activated. */
+    @Test
+    public void testIsRegistered_activeSession() throws Exception {
+        /* setup test */
+        /* train mocks */
+        when(accessTokenService.isSessionActive(IDENTITY_PROVIDER_TOKEN)).thenReturn(true);
+
+        /* make call */
+        /* verify results */
+        assertTrue(toTest.isRegistered(AUTH_HEADER_IP));
+    }
+
+    /** Should allow token found by identity provider. */
+    @Test
+    public void testIsRegistered_inactiveSession() throws Exception {
+        /* setup test */
+        assertNotNull(mockClueRideIdentity);
+        assertNotNull(mockBadgeOsPrincipal);
+
+        /* train mocks */
+        when(accessTokenService.isSessionActive(IDENTITY_PROVIDER_TOKEN)).thenReturn(false);
+        /* simulate finding the identity */
+        when(accessTokenService.getIdentity(IDENTITY_PROVIDER_TOKEN)).thenReturn(mockClueRideIdentity);
+        /* simulate finding that identity in our Badge OS DB */
+        when(badgeOsPrincipalService.getBadgeOsPrincipal(mockClueRideIdentity.getEmail()))
+                .thenReturn(mockBadgeOsPrincipal);
+
+        /* make call */
+        /* verify results */
+        assertTrue(toTest.isRegistered(AUTH_HEADER_IP));
+    }
+
+    /** Should forbid token that isn't test token or not found by identity provider. */
+    @Test
+    public void testIsRegistered_inactiveSession_notFound() throws Exception {
+        /* setup test */
+        /* train mocks */
+        when(accessTokenService.isSessionActive(IDENTITY_PROVIDER_TOKEN)).thenReturn(false);
+        doThrow(new RecordNotFoundException()).when(accessTokenService).getIdentity(IDENTITY_PROVIDER_TOKEN);
+
+        /* make call */
+        /* verify results */
+        assertFalse(toTest.isRegistered(AUTH_HEADER_IP));
+    }
+
+    // TODO: CA-405 is expected to expand this list to further cover the module under test.
+
+    /** Should allow valid Test Token. */
+    @Test
+    public void testIsRegistered_testToken() throws Exception {
+        /* setup test */
+        /* train mocks */
+        when(accessTokenService.isSessionActive(TEST_TOKEN)).thenReturn(false);
+        when(configService.getTestToken()).thenReturn(TEST_TOKEN);
+
+        /* make call */
+        /* verify results */
+        assertTrue(toTest.isRegistered(AUTH_HEADER_TEST));
+    }
+
+    /** Should forbid null token. */
+    @Test
+    public void testIsRegistered_null() throws Exception {
+        assertFalse(toTest.isRegistered(null));
+    }
+
+    /** Should forbid empty token. */
+    @Test
+    public void testIsRegistered_empty() throws Exception {
+        assertFalse(toTest.isRegistered(""));
+    }
+
+    /** Should forbid malformed token. */
+    @Test
+    public void testIsRegistered_malformed() throws Exception {
+        assertFalse(toTest.isRegistered(TEST_TOKEN));
+    }
+
+}

--- a/src/test/java/com/clueride/auth/state/TestResources.java
+++ b/src/test/java/com/clueride/auth/state/TestResources.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/18/18.
+ */
+package com.clueride.auth.state;
+
+import javax.enterprise.inject.Produces;
+
+import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.domain.account.principal.BadgeOsPrincipal;
+
+/**
+ * Provides Test-oriented CDI bindings.
+ */
+public class TestResources {
+
+    @Produces
+    ClueRideIdentity produceClueRideIdentity() {
+        ClueRideIdentity.Builder builder =
+                ClueRideIdentity.Builder.builder()
+                        .withSub("")
+                        .withGivenName("Test")
+                        .withFamilyName("Record")
+                        .withNickName("skank")
+                        .withDisplayName("skank")
+                        .withEmailString("test.email@clueride.com")
+                        .withPictureUrl("http://clueride.com/favicon.ico");
+
+        return  builder.build();
+    }
+
+    @Produces
+    BadgeOsPrincipal produceBadgeOsPrincipal() {
+        BadgeOsPrincipal.Builder builder =
+                BadgeOsPrincipal.Builder.builder()
+                        .withName("skank")
+                        .withId(-2)
+                        .withEmailAddressString("test.email@clueride.com");
+
+        return builder.build();
+    }
+
+}

--- a/src/test/java/com/clueride/auth/state/testng-verbose-logging.xml
+++ b/src/test/java/com/clueride/auth/state/testng-verbose-logging.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Default Suite" verbose="10">
+  <test name="server">
+    <classes>
+      <class name="com.clueride.auth.state.AccessStateServiceImplTest"/>
+    </classes>
+  </test> <!-- server -->
+</suite> <!-- Default Suite -->


### PR DESCRIPTION
- Adds webservice and service for AccessState along with TestNG unit test.
- Begins work on CA-405 to update records when we get a new Identity.

Also:
- Removes forced parsing of URL and InternetAddress fields at build() time.