### PR TITLE
CA-402 Logback implementation of SLF4J

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -9,6 +9,6 @@ log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t): 
 log4j.appender.APP_LOG=org.apache.log4j.FileAppender
 log4j.appender.APP_LOG.File=clueride_app.log
 log4j.appender.APP_LOG.layout=org.apache.log4j.PatternLayout
-# This format matches what WildFly is using:
-log4j.appender.APP_LOG.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
+# This format matches what WildFly is using (except for full date):
+log4j.appender.APP_LOG.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
 


### PR DESCRIPTION
Well, just updated the date format since WildFly is fairly tied to
its built-in logging sub-system.  More details on the ticket.