### PR TITLE
CA-352 Refactor DataStore from file-based to JPA-based for Outings

### DIFF
--- a/src/main/java/com/clueride/domain/account/member/MemberService.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberService.java
@@ -28,12 +28,20 @@ import com.clueride.auth.identity.ClueRideIdentity;
  * Provides business-layer services for Members and their Badges.
  */
 public interface MemberService {
+
     /**
      * Returns the entire list of members contained within the store.
      * TODO: This won't be sustainable once we have a significant number of members, but it's sufficient for testing.
      * @return List of the Members currently defined.
      */
     List<Member> getAllMembers();
+
+    /**
+     * Given a Member's ID, retrieve the matching record.
+     * @param id Unique ID for the Member.
+     * @return matching Member.
+     */
+    Member getMember(Integer id);
 
     /**
      * Retrieve Member instances by Email Address (Principal).

--- a/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
@@ -59,6 +59,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public Member getMember(Integer id) {
+        LOGGER.debug("Requesting member with ID: {}", id);
+        return memberStore.getMemberById(id).build();
+    }
+
+    @Override
     public Member getMemberByEmail(String emailAddress) throws AddressException {
         LOGGER.debug("Requesting Member by email " + emailAddress);
         InternetAddress email = new InternetAddress(emailAddress);

--- a/src/main/java/com/clueride/domain/course/Course.java
+++ b/src/main/java/com/clueride/domain/course/Course.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/15/16.
+ */
+package com.clueride.domain.course;
+
+import java.util.List;
+
+import com.clueride.domain.location.Location;
+import com.clueride.domain.path.Path;
+
+/**
+ * Representation of a Course, including an ordered list of Locations and the Paths
+ * which move from one Location to the next.
+ */
+public interface Course {
+    Integer getId();
+    String getName();
+    String getDescription();
+    Integer getCourseTypeId();
+    List<Step> getSteps();
+    List<Integer> getPathIds();
+    Location getDeparture();
+    Location getDestination();
+
+    // TODO: CA-374
+//    Step nextStep();
+//    Step currentStep();
+
+    /**
+     * As progress is made along the course, each step is completed by calling
+     * this method.
+     * For example, upon departure from the first {@link Location}, that step is completed
+     * and the state changes to the first {@link Path}.
+     * @return The last current step which we've marked as completed (giving us a new current Step).
+     */
+//    Step completeCurrentStep();
+}

--- a/src/main/java/com/clueride/domain/course/CourseStore.java
+++ b/src/main/java/com/clueride/domain/course/CourseStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/17/16.
+ */
+package com.clueride.domain.course;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Persistence interface for {@link Course} instances.
+ */
+public interface CourseStore {
+    /**
+     * Accepts fully constructed {@link Course} to the store and returns the ID.
+     *
+     * @param course - instance to be added to the memory-based copy (which may be persisted).
+     * @return Unique Integer ID of the new Course.
+     * @throws IOException if there is a problem writing to disk.
+     */
+    Integer addNew(Course course) throws IOException;
+
+    /**
+     * Retrieve the {@link Course} matching the ID from the store.
+     * @param id - Unique identifier for the Course.
+     * @return the matching Course.
+     */
+    Course getCourseById(Integer id);
+
+    /**
+     * Accept the {@link Course} instance as a replacement for the existing Course with
+     * the same ID as this Course instance.
+     * @param course - Instance of Course to replace the one already in the store.
+     */
+    void update(Course course);
+
+    /**
+     * Returns Metadata for all Courses.
+     * @return List of all Courses.
+     */
+    List<Course> getCourses();
+
+}

--- a/src/main/java/com/clueride/domain/course/CourseType.java
+++ b/src/main/java/com/clueride/domain/course/CourseType.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/10/16.
+ */
+package com.clueride.domain.course;
+
+import java.net.URL;
+
+/**
+ * Model for the Type of Course: Enumeration of Type is linked to a specific Course and
+ * holds details of that Course Type:<ul>
+ *     <li>ID</li>
+ *     <li>Type (name)</li>
+ *     <li>Description</li>
+ *     <li>URL of web page holding further details.</li>
+ * </ul>
+ */
+public class CourseType {
+    private final Integer id;
+    private final String type;
+    private final String description;
+    private final URL url;
+
+    public CourseType(Builder builder) {
+        id = builder.getId();
+        type = builder.getType();
+        description = builder.getDescription();
+        url = builder.getUrl();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    /**
+     * Builder pattern implements interface to allow construction of a given type.
+     */
+    public static final class Builder {
+        private Integer id;
+        private String type;
+        private String description;
+        private URL url;
+
+        public CourseType build() {
+            return new CourseType(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(CourseType instance) {
+            return builder()
+                    .setId(instance.id)
+                    .setDescription(instance.description)
+                    .setType(instance.type)
+                    .setUrl(instance.url)
+                    ;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder setId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public Builder setType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Builder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public URL getUrl() {
+            return url;
+        }
+
+        public Builder setUrl(URL url) {
+            this.url = url;
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/clueride/domain/course/CourseTypeStore.java
+++ b/src/main/java/com/clueride/domain/course/CourseTypeStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/10/16.
+ */
+package com.clueride.domain.course;
+
+import java.io.IOException;
+
+/**
+ * Persistence interface for {@link CourseType} instances.
+ */
+public interface CourseTypeStore {
+    /**
+     * Accepts fully-populated CourseType instance and returns the ID of a newly persisted record.
+     *
+     * Since the creation of a new instance a) occurs infrequently and b) requires manual creation/editing
+     * of web pages on the main website, this method may not be used.
+     *
+     * @param courseType - Fully-populated instance.
+     * @return Integer DB-generated ID.
+     * @throws IOException when there is trouble writing to the store.
+     */
+    Integer addNew(CourseType courseType) throws IOException;
+
+    /**
+     * Given a specific Course Type identifier, return the matching {@link CourseType} instance.
+     * @param courseTypeId - Unique Integer ID representing the CourseType.
+     * @return Matching CourseType.
+     */
+    CourseType getCourseTypeById(Integer courseTypeId);
+
+}

--- a/src/main/java/com/clueride/domain/course/FilledCourse.java
+++ b/src/main/java/com/clueride/domain/course/FilledCourse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/15/18.
+ */
+package com.clueride.domain.course;
+
+/**
+ * Course that has all the links to other objects populated.
+ */
+public interface FilledCourse extends Course {
+    /** Starting out as a "Marker" sort of interface. */
+    // TODO: CA-374
+}

--- a/src/main/java/com/clueride/domain/course/GameCourse.java
+++ b/src/main/java/com/clueride/domain/course/GameCourse.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/15/18.
+ */
+package com.clueride.domain.course;
+
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.clueride.domain.game.GameState;
+import com.clueride.domain.location.Location;
+
+/**
+ * Contains static information about a Course; persistable to DB and unchanging
+ * over the time frame of an Outing.
+ *
+ * This serves as a reference to obtain information about the structure of the
+ * course. The dynamic state information is held in the {@link GameState} instance.
+ */
+@Immutable
+public class GameCourse implements Course {
+    private final Integer id;
+    private final String name;
+    private final String description;
+    private final Integer courseTypeId;
+    private final List<Step> steps;
+    private final List<Integer> pathIds;
+    private final Location departure;
+    private final Location destination;
+
+    private GameCourse(Builder builder) {
+        this.id = builder.getId();
+        this.name = builder.getName();
+        this.description = builder.getDescription();
+        this.courseTypeId = builder.getCourseTypeId();
+        this.steps = builder.getSteps();
+        this.pathIds = builder.getPathIds();
+        this.departure = builder.getDeparture();
+        this.destination = builder.getDestination();
+    }
+
+    @Override
+    public Integer getId() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public Integer getCourseTypeId() {
+        return null;
+    }
+
+    @Override
+    public List<Step> getSteps() {
+        return null;
+    }
+
+    @Override
+    public List<Integer> getPathIds() {
+        return null;
+    }
+
+    @Override
+    public Location getDeparture() {
+        return null;
+    }
+
+    @Override
+    public Location getDestination() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    public static class Builder {
+        private Integer id;
+        private String name;
+        private String description;
+        private Integer courseTypeId;
+        private List<Step> steps;
+        private List<Integer> pathIds;
+        private Location departure;
+        private Location destination;
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(Course course) {
+            return builder()
+                    .withId(course.getId())
+                    .withName(course.getName())
+                    .withDescription(course.getDescription())
+                    .withCourseTypeId(course.getCourseTypeId())
+                    .withSteps(course.getSteps())
+                    ;
+        }
+
+        public GameCourse build() {
+            return new GameCourse(this);
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Integer getCourseTypeId() {
+            return courseTypeId;
+        }
+
+        public Builder withCourseTypeId(Integer courseTypeId) {
+            this.courseTypeId = courseTypeId;
+            return this;
+        }
+
+        public List<Step> getSteps() {
+            return steps;
+        }
+
+        public Builder withSteps(List<Step> steps) {
+            this.steps = steps;
+            return this;
+        }
+
+        public List<Integer> getPathIds() {
+            return pathIds;
+        }
+
+        public Builder withPathIds(List<Integer> pathIds) {
+            this.pathIds = pathIds;
+            return this;
+        }
+
+        public Location getDeparture() {
+            return departure;
+        }
+
+        public Builder withDeparture(Location departure) {
+            this.departure = departure;
+            return this;
+        }
+
+        public Location getDestination() {
+            return destination;
+        }
+
+        public Builder withDestination(Location destination) {
+            this.destination = destination;
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/com/clueride/domain/course/Step.java
+++ b/src/main/java/com/clueride/domain/course/Step.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/15/16.
+ */
+package com.clueride.domain.course;
+
+/**
+ * "Marker" interface for Locations and Paths which helps keep order.
+ *
+ * The next Step at a Location will be a {@link Path} (or choice of Paths).  The next Step while
+ * on a Path will be arrival at the next Location.
+ *
+ * This allows an ordered list of Steps without necessarily worrying about whether the next
+ * one comes from the Location List or the Path List, or whatever else we might want to
+ * stick in a {@link Course}.
+ */
+public interface Step {
+
+}

--- a/src/main/java/com/clueride/domain/game/GameState.java
+++ b/src/main/java/com/clueride/domain/game/GameState.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/14/18.
+ */
+package com.clueride.domain.game;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Defines what we need to track the state of the Game for the clients.
+ */
+@Immutable
+public class GameState {
+    private final Boolean teamAssembled;
+    private final Boolean rolling;
+    private final String nextLocation;
+    private final Integer pathIndex;
+
+    private GameState(Builder builder) {
+        this.teamAssembled = builder.getTeamAssembled();
+        this.rolling = builder.getRolling();
+        this.nextLocation = builder.getNextLocation();
+        this.pathIndex = builder.getPathIndex();
+    }
+
+    public Boolean getTeamAssembled() {
+        return teamAssembled;
+    }
+
+    public Boolean getRolling() {
+        return rolling;
+    }
+
+    public String getNextLocation() {
+        return nextLocation;
+    }
+
+    public Integer getPathIndex() {
+        return pathIndex;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public static class Builder {
+        /* Initial Game State */
+        private Boolean teamAssembled = false;
+        private Boolean rolling = false;
+        private String nextLocation = "Meeting Location";
+        private Integer pathIndex = 0;
+
+        public GameState build() {
+            return new GameState(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(GameState gameState) {
+            return builder()
+                    .withTeamAssembled(gameState.getTeamAssembled())
+                    .withRolling(gameState.getRolling())
+                    .withNextLocation(gameState.getNextLocation())
+                    .withPathIndex(gameState.getPathIndex());
+        }
+
+        public Boolean getTeamAssembled() {
+            return teamAssembled;
+        }
+
+        public Builder withTeamAssembled(Boolean teamAssembled) {
+            this.teamAssembled = teamAssembled;
+            return this;
+        }
+
+        public Boolean getRolling() {
+            return rolling;
+        }
+
+        public Builder withRolling(Boolean rolling) {
+            this.rolling = rolling;
+            return this;
+        }
+
+        public String getNextLocation() {
+            return nextLocation;
+        }
+
+        public Builder withNextLocation(String nextLocation) {
+            this.nextLocation = nextLocation;
+            return this;
+        }
+
+        public Integer getPathIndex() {
+            return pathIndex;
+        }
+
+        public Builder withPathIndex(Integer pathIndex) {
+            this.pathIndex = pathIndex;
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/com/clueride/domain/game/GameStateService.java
+++ b/src/main/java/com/clueride/domain/game/GameStateService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/24/16.
+ */
+package com.clueride.domain.game;
+
+/**
+ * Manages an in-memory copy of the State per Team and per User Session.
+ */
+public interface GameStateService {
+    /**
+     * Given a Team's ID, return the most recently stored State for that Team.
+     * @param teamId - Unique Integer identifying the Team whose State to be retrieved.
+     * @return - JSON String representing the entire state object.
+     */
+    String getGameStateByTeam(Integer teamId);
+
+    /**
+     * Update the stored Game State for a team using the given instance.
+     * @param clueRideState - State values to be used for the update.
+     * @return - JSON object indicating success of update.
+     */
+//    String updateGameStateByTeam(ClueRideState clueRideState);
+
+    /**
+     * Indicates that an initial game has all players assembled and we're
+     * ready to reveal a puzzle at the starting location.
+     * @param outingId - Unique identifier for the Outing, generally from the session.
+     * @return updated Game State instance.
+     */
+    GameState updateWithTeamAssembled(Integer outingId);
+
+    /**
+     * Updates the indicated Outing with an Arrival Event (including the broadcast of the SSE.
+     * This is only valid after the first departure from the starting location;
+     * it cannot be used to trigger arrival at the start, that's the job for
+     * {@link GameStateService#updateWithTeamAssembled(Integer)}
+     * @param outingId Identifies the Outing (usually taken from the session).
+     */
+    GameState updateOutingStateWithArrival(Integer outingId);
+
+    /**
+     * Updates the indicated Outing with a Departure Event (including the broadcast of the SSE.
+     * @param outingId Identifies the Outing (usually taken from the session).
+     */
+    GameState updateOutingStateWithDeparture(Integer outingId);
+
+}

--- a/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/24/16.
+ */
+package com.clueride.domain.game;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+import com.clueride.domain.game.ssevent.SSEventService;
+
+/**
+ * Implementation of service handling Game State.
+ */
+public class GameStateServiceImpl implements GameStateService {
+    @Inject
+    private Logger LOGGER;
+
+    private final SSEventService ssEventService;
+
+    /** Cached copy of GameState TODO: Persist this via a service. */
+    private static Map<Integer, GameState> gameStateMap = new HashMap<>();
+
+    @Inject
+    public GameStateServiceImpl(
+            SSEventService ssEventService
+    ) {
+        this.ssEventService = ssEventService;
+    }
+
+    @Override
+    public String getGameStateByTeam(Integer teamId) {
+        LOGGER.info("Requesting Game State for Team ID " + teamId);
+        return "";
+    }
+
+    @Override
+    public GameState updateWithTeamAssembled(Integer outingId) {
+        LOGGER.info("Opening Game State for outing " + outingId);
+        GameState gameState = GameState.Builder.builder()
+                .withTeamAssembled(true)
+                .build();
+        gameStateMap.put(outingId, gameState);
+        ssEventService.sendTeamReadyEvent(outingId);
+        return gameState;
+    }
+
+    @Override
+    public GameState updateOutingStateWithArrival(Integer outingId) {
+        LOGGER.info("Changing Game State for outing " + outingId + " to Arrival");
+        GameState gameState = gameStateMap.get(outingId);
+        if (!gameState.getRolling()) {
+            throw new IllegalStateException("Cannot Arrive if not yet rolling");
+        }
+
+        gameState = GameState.Builder.from(gameState)
+                .withTeamAssembled(true)
+                .withRolling(false)
+                .build();
+        gameStateMap.put(outingId, gameState);
+        ssEventService.sendArrivalEvent(outingId);
+        return gameState;
+    }
+
+    @Override
+    public GameState updateOutingStateWithDeparture(Integer outingId) {
+        LOGGER.info("Changing Game State for outing " + outingId + " to Departure");
+        GameState gameState = gameStateMap.get(outingId);
+        if (gameState.getRolling()) {
+            throw new IllegalStateException("Cannot depart if still rolling");
+        }
+        GameState.Builder gameStateBuilder = GameState.Builder.from(gameState);
+        gameStateBuilder.withRolling(true)
+                .withPathIndex(gameStateBuilder.getPathIndex() + 1);
+
+        gameState = gameStateBuilder.build();
+
+        gameStateMap.put(outingId, gameState);
+        ssEventService.sendDepartureEvent(outingId);
+        return gameState;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/15/18.
+ */
+package com.clueride.domain.game.ssevent;
+
+/**
+ * Handles the generation and propagation of Events from the Game's point of view.
+ *
+ * Implementations will call into the Server-Sent Event Server to actuall perform the
+ * broadcast to subscribers.
+ */
+public interface SSEventService {
+    /**
+     * After the team is assembled and ready to play, this is the signal
+     * we're beginning the game.
+     *
+     * @param outingId Unique identifier for the Outing that is beginning play; indicates which channel is updated.
+     * @return ID of the message.
+     */
+    Integer sendTeamReadyEvent(Integer outingId);
+
+    Integer sendArrivalEvent(Integer outingId);
+
+    Integer sendDepartureEvent(Integer outingId);
+
+}

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/15/18.
+ */
+package com.clueride.domain.game.ssevent;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+
+/**
+ * Sends formatted JSON string representing expected SSE event message to Broadcast server for SSE.
+ *
+ * Picks up the SSE Host information from System Property.
+ */
+public class SSEventServiceImpl implements SSEventService {
+    @Inject
+    private Logger LOGGER;
+
+    private final String sseHost;
+
+    public SSEventServiceImpl() {
+        this.sseHost = System.getProperty("sse-host");
+        LOGGER.debug("Communicating with SSE server at " + sseHost);
+    }
+
+    @Override
+    public Integer sendTeamReadyEvent(Integer outingId) {
+        return sendEvent(outingId, eventMessageFromString("Team Assembled", outingId));
+    }
+
+    @Override
+    public Integer sendArrivalEvent(Integer outingId) {
+        return sendEvent(outingId, eventMessageFromString("Arrival", outingId));
+    }
+
+    @Override
+    public Integer sendDepartureEvent(Integer outingId) {
+        return sendEvent(outingId, eventMessageFromString("Departure", outingId));
+    }
+
+    private String eventMessageFromString(String event, Integer outingId) {
+        return String.format("{\"event\":\"%s\",\"outingId\":%d}", event, outingId);
+    }
+
+    /**
+     * Bundles up the formatted message for sending as a post to the game state broadcast URL.
+     * @param outingId Identifier for the Outing which tells which channel to broadcast.
+     * @param message JSON-formatted plain text to be sent as the message.
+     * @return the HTTP Response code (exception thrown if it's not 200).
+     */
+    private Integer sendEvent(
+            Integer outingId,
+            String message
+    ) {
+        Integer responseCode = 500;
+        try {
+            URL url = new URL("http://" + sseHost + "/rest/game-state-broadcast/" + outingId);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "text/plain");
+
+            OutputStream os = conn.getOutputStream();
+            os.write(message.getBytes());
+            os.flush();
+
+            responseCode = conn.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new RuntimeException("Failed : HTTP error code : "
+                        + responseCode);
+            }
+
+            BufferedReader br = new BufferedReader(
+                    new InputStreamReader(
+                            conn.getInputStream()
+                    )
+            );
+
+            String output;
+            LOGGER.debug("Output from SSE Server:");
+            while ((output = br.readLine()) != null) {
+                LOGGER.debug(output);
+            }
+
+            conn.disconnect();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return responseCode;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -1,0 +1,537 @@
+/**
+ *   Copyright 2015 Jett Marks
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created Aug 15, 2015
+ */
+package com.clueride.domain.location;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Transient;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.clueride.domain.course.Step;
+import com.clueride.domain.location.latlon.LatLon;
+import com.clueride.domain.location.loctype.LocationType;
+import com.clueride.domain.puzzle.Puzzle;
+
+/**
+ * Holds the data for a Location, and provides some of the logic to provide derived properties.
+ *
+ * @author jett
+ */
+@Immutable
+public class Location implements Step {
+    private final Integer id;
+    private final String name;
+    private final String description;
+    private final LocationType locationType;
+    private final Integer nodeId;
+    private final URL featuredImage;
+    private final Integer googlePlaceId;
+    private final LatLon latLon;
+    private final ReadinessLevel readinessLevel;
+    private List<Puzzle.Builder> puzzleBuilders;
+    private final List<URL> imageUrls;
+    private final Integer locationGroupId;
+    private final String establishment;
+    private final Integer establishmentId;
+    private final Map<String,Optional<Double>> tagScores;
+    private final static Integer SYNCH_LOCK = -1;
+
+    /**
+     * Constructor accepting Builder instance.
+     * @param builder instance carrying mutable Location.
+     */
+    public Location(Builder builder) {
+        id = builder.getId();
+        nodeId = builder.getNodeId();
+        latLon = builder.getLatLon();
+        readinessLevel = builder.getReadinessLevel();
+
+        // If any of these are missing, we're at the Draft level
+        name = builder.getName();
+        description = builder.getDescription();
+        locationType = builder.getLocationType();
+        featuredImage = builder.getFeaturedImage();
+
+        // If we have multiple images, the ranking goes up
+        imageUrls = builder.getImageUrls();
+
+        // If this is missing, we're at the Place level; present, we're at the Attraction level
+        puzzleBuilders = builder.getPuzzleBuilders();
+
+        // Featured Level requires the following
+        googlePlaceId = builder.getGooglePlaceId();
+
+        // Possibly empty list
+        tagScores = builder.getTagScores();
+
+        // Optional values
+        locationGroupId = builder.getLocationGroupId();
+        establishmentId = builder.getEstablishmentId();
+        establishment = builder.getEstablishment();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * Human readable name for this location.
+     * Shows up in headings for the Location, Lists of Locations, and as pop-ups on the map.
+     * @return String representing human-readable name of Location.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Textual description of this Location.
+     * Describes why this location is interesting.
+     * @return String representing a description of this Location.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Enumeration of the type of Location.
+     * Plays a role in helping select locations and categorizes them.
+     * @return Enumeration of the type of Location.
+     */
+    public Integer getLocationTypeId() {
+        return locationType.getId();
+    }
+
+    public String getLocationTypeName() {
+        return locationType.getName();
+    }
+
+    /**
+     * Link over to the geographical representation of this Location.
+     * @return ID of the LatLon associated with this location for placement on a map.
+     */
+    public Integer getNodeId() {
+        return nodeId;
+    }
+
+    public LatLon getLatLon() {
+        return latLon;
+    }
+
+    public Map<String, Optional<Double>> getTagScores() {
+        return tagScores;
+    }
+
+    /**
+     * This method returns null for an empty Location Group to
+     * accommodate the JSON writer, but not sure this is what
+     * we'll continue to want.
+     * @return Integer or null if not present.
+     */
+    public Integer getLocationGroupId() {
+        if(locationGroupId != null) {
+            return locationGroupId;
+        } else {
+            return null;
+        }
+    }
+
+    public Integer getEstablishment() {
+        return establishmentId;
+    }
+
+    public URL getFeaturedImage() {
+        return featuredImage;
+    }
+
+    public List<URL> getImageUrls() {
+        return imageUrls;
+    }
+
+    /**
+     * Determines progress against criteria described here: http://bikehighways.wikidot.com/clueride-location-details
+     * @return Readiness level based on completeness of the fields for this object.
+     */
+    public ReadinessLevel getReadinessLevel() {
+        return readinessLevel;
+    }
+
+    public Integer getGooglePlaceId() {
+        return googlePlaceId;
+    }
+
+    /**
+     * List of Strings that in addition to LocationType, each categorize the location.
+     * Perhaps a placeholder at this time until I think through further what sorts of tags might be applied.
+     * @return Set of Strings, one for each tag added to this location.
+    public Set<String> getTags() {
+    return tagScores.keySet();
+    }
+     */
+
+    // TODO: not settled on this API
+    public Optional<Double> getScorePerTag(String tag) {
+        return tagScores.get(tag);
+    }
+
+    // TODO: CA-324 -- Move this logic into the service
+    public void removePuzzle(Integer puzzleId) {
+        synchronized(SYNCH_LOCK) {
+            List<Puzzle.Builder> remainingPuzzles = new ArrayList<>();
+            for (Puzzle.Builder builder : puzzleBuilders) {
+                if (!puzzleId.equals(builder.getId()) && builder != null) {
+                    remainingPuzzles.add(builder);
+                }
+            }
+            this.puzzleBuilders = ImmutableList.copyOf(remainingPuzzles);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    /**
+     * Knows how to assemble the parts of a Location.
+     */
+    @Entity(name="location")
+    public static final class Builder {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="location_pk_sequence")
+        @SequenceGenerator(name="location_pk_sequence",sequenceName="location_id_seq", allocationSize=1)
+        private Integer id;
+
+        private String name;
+        private String description;
+
+        @Column(name= "location_type_id") private Integer locationTypeId;
+
+        @Column(name="node_id") private Integer nodeId;
+        @Column(name="featured_image_id") private Integer featuredImageId;
+
+        @OneToMany(mappedBy = "locationBuilder")
+        private List<Puzzle.Builder> puzzleBuilders;
+
+        // TODO: CA-325 - Coming out after we abandon the Json Clues
+        @Transient
+        private List<Integer> clueIds;
+
+        @Transient
+        private LocationType locationType;
+        @Transient
+        private String locationTypeName;
+        @Transient
+        private LatLon latLon;
+        @Transient
+        private List<URL> imageUrls;
+        @Transient
+        private URL featuredImage;
+        @Transient
+        private Integer googlePlaceId;
+
+        @Transient
+        private Integer establishmentId;
+        @Column(name="location_group_id") private Integer locationGroupId;
+
+        @Transient
+        private Map<String,Optional<Double>> tagScores = new HashMap<>();
+
+        @Transient
+        private String establishment;
+
+        @Transient
+        private ReadinessLevel readinessLevel;
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(Location location) {
+            return builder()
+                    .withId(location.id)
+                    .withName(location.name)
+                    .withDescription(location.description)
+                    .withLocationType(location.locationType)
+                    .withNodeId(location.getNodeId())
+                    .withLatLon(location.latLon)
+                    .withPuzzleBuilders(location.puzzleBuilders)
+                    .withFeaturedImage(location.featuredImage)
+                    .withImageUrls(location.imageUrls)
+                    .withEstablishmentId(location.establishmentId)
+                    .withTagScores(location.tagScores)
+                    ;
+        }
+
+        public Location build() {
+            if (locationType == null) {
+                throw new IllegalStateException("Location Type cannot be null");
+            }
+            return new Location(this);
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * If the value has been set (by reading from the LocationStore), use that
+         * value, otherwise, we're creating a new instance the and idProvider should
+         * give us the next available value.
+         * @return Unique ID for this instance of Location.
+         */
+        public Integer getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public LocationType getLocationType() {
+            return locationType;
+        }
+
+        public Builder withLocationTypeId(Integer locationTypeId) {
+            this.locationTypeId = locationTypeId;
+            return this;
+        }
+
+        public Integer getLocationTypeId() {
+            return locationTypeId;
+        }
+
+        public Builder withLocationTypeName(String locationTypeName) {
+            this.locationTypeName = locationTypeName;
+            return this;
+        }
+
+        public String getLocationTypeName() {
+            return this.locationTypeName;
+        }
+
+        public void setLocationType(LocationType locationType) {
+            this.withLocationType(locationType);
+        }
+
+        public Builder withLocationType(LocationType locationType) {
+            this.locationType = locationType;
+            this.locationTypeId = locationType.getId();
+            return this;
+        }
+
+        public Builder withReadinessLevel(ReadinessLevel readinessLevel) {
+            this.readinessLevel = readinessLevel;
+            return this;
+        }
+
+        public Integer getNodeId() {
+            return nodeId;
+        }
+
+        public Builder withNodeId(Integer nodeId) {
+            this.nodeId = nodeId;
+            return this;
+        }
+
+        public List<Puzzle.Builder> getPuzzleBuilders() {
+            return puzzleBuilders;
+        }
+
+        public Builder withPuzzleBuilders(List<Puzzle.Builder> puzzleBuilders) {
+            this.puzzleBuilders = puzzleBuilders;
+            return this;
+        }
+
+        public Builder addPuzzleBuilder(Puzzle.Builder puzzleBuilder) {
+            this.puzzleBuilders.add(puzzleBuilder);
+            return this;
+        }
+
+        public Map<String, Optional<Double>> getTagScores() {
+            return tagScores;
+        }
+
+        public Builder withTagScores(Map<String, Optional<Double>> tagScores) {
+            this.tagScores = tagScores;
+            return this;
+        }
+
+        public Integer getLocationGroupId() {
+            return locationGroupId;
+        }
+
+        public Builder withLocationGroupId(Integer locationGroupId) {
+            this.locationGroupId = locationGroupId;
+            return this;
+        }
+
+        public Integer getEstablishmentId() {
+            return establishmentId;
+        }
+
+        public Builder withEstablishmentId(Integer establishmentId) {
+            this.establishmentId = establishmentId;
+            return this;
+        }
+
+        public String getEstablishment() {
+            return establishment;
+        }
+
+        public Builder withEstablishment(String establishment) {
+            this.establishment = establishment;
+            return this;
+        }
+
+        public List<URL> getImageUrls() {
+            if (imageUrls != null) {
+                return imageUrls;
+            } else {
+                return Collections.emptyList();
+            }
+        }
+
+        public Builder withImageUrls(List<URL> imageUrls) {
+            this.imageUrls = imageUrls;
+            return this;
+        }
+
+        public LatLon getLatLon() {
+            return latLon;
+        }
+
+        public Builder withLatLon(LatLon latLon) {
+            this.latLon = latLon;
+            if (latLon != null) {
+                this.nodeId = latLon.getId();
+            }
+            return this;
+        }
+
+        public URL getFeaturedImage() {
+            return featuredImage;
+        }
+
+        public Builder withFeaturedImage(URL featuredImage) {
+            this.featuredImage = featuredImage;
+            return this;
+        }
+
+        public Builder clearFeaturedImage() {
+            this.featuredImageId = null;
+            this.featuredImage = null;
+            return this;
+        }
+
+        public boolean hasNoFeaturedImage() {
+            return featuredImageId == null;
+        }
+
+        public Integer getFeaturedImageId() {
+            return featuredImageId;
+        }
+
+        public Builder withFeaturedImageId(int imageId) {
+            this.featuredImageId = imageId;
+            return this;
+        }
+
+        public Integer getGooglePlaceId() {
+            return googlePlaceId;
+        }
+
+        public Builder withGooglePlaceId(Integer googlePlaceId) {
+            this.googlePlaceId = googlePlaceId;
+            return this;
+        }
+
+        public ReadinessLevel getReadinessLevel() {
+            return readinessLevel;
+        }
+
+        /**
+         * Accepts a partial set of information -- generally posted from REST API -- and updates this copy with the
+         * new fields.
+         * @param locationBuilder instance with the new info.
+         */
+        public void updateFrom(Builder locationBuilder) {
+            this
+                    .withName(locationBuilder.name)
+                    .withId(locationBuilder.id)
+                    .withDescription(locationBuilder.description)
+                    .withNodeId(locationBuilder.nodeId)
+                    .withLocationTypeId(locationBuilder.locationTypeId)
+                    .withLocationGroupId(locationBuilder.locationGroupId)
+                    .withImageUrls(locationBuilder.imageUrls);
+        }
+
+        /* TODO: CA-325 Only useful for moving from JSON to JPA; remove after JSON is abandoned for Clues. */
+        public List<Integer> getClueIds() {
+            return clueIds;
+        }
+
+        public Builder withClueIds(List<Integer> clueIds) {
+            this.clueIds = clueIds;
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/com/clueride/domain/location/LocationStore.java
+++ b/src/main/java/com/clueride/domain/location/LocationStore.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2015 Jett Marks
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p/>
+ * Created by jett on 11/23/15.
+ */
+package com.clueride.domain.location;
+
+import java.io.IOException;
+import java.util.Collection;
+
+// TODO: CA-309: Location Store API is straddling two implementations; clean these up.
+public interface LocationStore {
+
+    /**
+     * Accepts a fully constructed Location to the store and returns the ID.
+     * Implementations are expected to write to permanent storage.
+     * @param location newly and fully constructed Location, ready to persist.
+     * @return ID of the new Location.
+     * @deprecated prefer Builder.
+     */
+    @Deprecated
+    Integer addNew(Location location) throws IOException;
+
+    /**
+     * Accepts a partially constructed Location to the store and returns the ID.
+     * Implementations are expected to write to permanent storage.
+     * @param locationBuilder newly proposed Location, ready to persist.
+     * @return ID of the new Location.
+     */
+    Integer addNew(Location.Builder locationBuilder) throws IOException;
+
+    /**
+     * Returns the Location matching the ID from the store.
+     *
+     * @param id of the Location we expect to retrieve from the store.
+     * @return Location with the given ID or null if no location is found.
+     * @deprecated prefer the Builder.
+     */
+    @Deprecated
+    Location getLocationById(Integer id);
+
+    /**
+     * Returns the Location Builder matching the unique ID.
+     * @param id unique identifier for the Location Builder.
+     * @return fully-populated Location Builder.
+     */
+    Location.Builder getLocationBuilderById(Integer id);
+
+    /**
+     * Returns the list of Locations maintained by this store.
+     *
+     * The Store is populated from persisted store upon instantiation, so
+     * the initial contents will come from some permanent storage.
+     * @return Collection of all Locations in the store.
+     * @deprecated - Prefer returning Builders so the Service can handle build() problems.
+     */
+    @Deprecated
+    Collection<Location> getLocations();
+
+    /**
+     * Returns the list of Location Builders maintained by this store.
+     * @return Collection of all Locations in the store.
+     */
+    Collection<Location.Builder> getLocationBuilders();
+
+    /**
+     * Accepts an existing Location and updates the persistent record with new information.
+     * @param location to be updated.
+     * @deprecated prefer Builder.
+     */
+    @Deprecated
+    void update(Location location);
+
+    /**
+     * Accepts an existing Location and updates the persistent record with new information.
+     * @param locationBuilder to be updated.
+     */
+    void update(Location.Builder locationBuilder);
+
+}

--- a/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * JPA Implementation of the LocationStore (DAO) interface.
+ */
+public class LocationStoreJpa implements LocationStore {
+
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    /**
+     * Likely to be removed.
+     * @param location newly and fully constructed Location, ready to persist.
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public Integer addNew(Location location) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Integer addNew(Location.Builder locationBuilder) throws IOException {
+        entityManager.getTransaction().begin();
+        entityManager.persist(locationBuilder);
+        entityManager.getTransaction().commit();
+        return locationBuilder.getId();
+    }
+
+    @Override
+    public Location getLocationById(Integer id) {
+        return null;
+    }
+
+    @Override
+    public Location.Builder getLocationBuilderById(Integer id) {
+        entityManager.getTransaction().begin();
+        Location.Builder locationBuilder = entityManager.find(Location.Builder.class, id);
+        entityManager.getTransaction().commit();
+        return locationBuilder;
+    }
+
+    @Override
+    public Collection<Location> getLocations() {
+        Collection<Location> locations = new ArrayList<>();
+        Collection<Location.Builder> builderCollection = getLocationBuilders();
+        for (Location.Builder builder : builderCollection) {
+            try {
+                locations.add(builder.build());
+            } catch (IllegalStateException ise) {
+                /* Defer to returning Builders; deprecated for now. */
+            }
+        }
+        return locations;
+    }
+
+    @Override
+    public Collection<Location.Builder> getLocationBuilders() {
+        Collection<Location.Builder> builderCollection = new ArrayList<>();
+        entityManager.getTransaction().begin();
+        List<Location.Builder> locationList = entityManager.createQuery(
+                "SELECT l FROM location l"
+        ).getResultList();
+        entityManager.getTransaction().commit();
+        builderCollection.addAll(locationList);
+        return builderCollection;
+    }
+
+    /**
+     * @deprecated - use method accepting Location.Builder.
+     * @param location to be updated.
+     */
+    @Override
+    public void update(Location location) {
+
+    }
+
+    @Override
+    public void update(Location.Builder locationBuilder) {
+        entityManager.getTransaction().begin();
+        entityManager.persist(locationBuilder);
+        entityManager.getTransaction().commit();
+    }
+}

--- a/src/main/java/com/clueride/domain/location/ReadinessLevel.java
+++ b/src/main/java/com/clueride/domain/location/ReadinessLevel.java
@@ -1,0 +1,32 @@
+package com.clueride.domain.location;
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/5/17.
+ */
+
+/**
+ * Defines the progressive readiness levels for a Location.
+ *
+ * See http://bikehighways.wikidot.com/clueride-location-details for business definitions.
+ */
+public enum ReadinessLevel {
+    NODE,
+    ISSUE,
+    DRAFT,
+    PLACE,
+    ATTRACTION,
+    FEATURED
+}

--- a/src/main/java/com/clueride/domain/location/latlon/LatLon.java
+++ b/src/main/java/com/clueride/domain/location/latlon/LatLon.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location.latlon;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Details of a proposed LatLon in support of Locations which may not yet be on the network.
+ *
+ * DTO at this time.
+ */
+
+@XmlRootElement
+@Entity(name="latlon")
+public class LatLon {
+    @Id
+    @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="latlon_pk_sequence")
+    @SequenceGenerator(name="latlon_pk_sequence",sequenceName="node_id_seq", allocationSize=1)
+    private Integer id;
+
+    private double lat;
+    private double lon;
+    private double elev;
+
+    /**
+     * Constructor to initialize the two most significant fields.
+     * @param lat latitude.
+     * @param lon longitude.
+     */
+    public LatLon(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+    public LatLon() {
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public LatLon setId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public double getLat() {
+        return lat;
+    }
+
+    public LatLon setLat(double lat) {
+        this.lat = lat;
+        return this;
+    }
+
+    public double getLon() {
+        return lon;
+    }
+
+    public LatLon setLon(double lon) {
+        this.lon = lon;
+        return this;
+    }
+
+    public double getElev() {
+        return elev;
+    }
+
+    public LatLon setElev(double elev) {
+        this.elev = elev;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/src/main/java/com/clueride/domain/location/latlon/LatLonService.java
+++ b/src/main/java/com/clueride/domain/location/latlon/LatLonService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location.latlon;
+
+/**
+ * Handles LatLon pairs; Nodes which are not necessarily on the Network yet.
+ */
+public interface LatLonService {
+    /**
+     * Provide a candidate LatLon and this will persist it to the store.
+     * @param latLon Candidate LatLon.
+     * @return the newly created LatLon complete with the ID from the DB.
+     */
+    LatLon addNew(LatLon latLon);
+
+    /**
+     * Given a LatLon ID, retrieve the corresponding LatLon.
+     * @param id unique ID for the LatLon.
+     * @return Location-supporting LatLon.
+     */
+    LatLon getLatLonById(Integer id);
+
+}

--- a/src/main/java/com/clueride/domain/location/latlon/LatLonServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/latlon/LatLonServiceImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location.latlon;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+/**
+ * Basically a wrapper for the DAO at this time.
+ */
+public class LatLonServiceImpl implements LatLonService {
+    private final LatLonStore latLonStore;
+
+    @Inject
+    public LatLonServiceImpl(
+            LatLonStore latLonStore
+    ) {
+        this.latLonStore = latLonStore;
+    }
+
+    @Override
+    public LatLon addNew(LatLon latLon) {
+        try {
+            latLonStore.addNew(latLon);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Storage problem");
+        }
+        return latLon;
+    }
+
+    @Override
+    public LatLon getLatLonById(Integer id) {
+        return latLonStore.getLatLonById(id);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/location/latlon/LatLonStore.java
+++ b/src/main/java/com/clueride/domain/location/latlon/LatLonStore.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location.latlon;
+
+import java.io.IOException;
+
+/**
+ * Responsible for persistence of Location-supporting Nodes.
+ */
+public interface LatLonStore {
+    /**
+     * Adds LatLon Proposal which may not (yet) be part of the Network.
+     * @param latLon Location-supporting LatLon.
+     * @return unique ID across all Nodes.
+     * @throws IOException from underlying implementation.
+     */
+    Integer addNew(LatLon latLon) throws IOException;
+
+    /**
+     * Given an ID, return the corresponding LatLon.
+     * @param id unique ID for the LatLon.
+     * @return matching LatLon.
+     */
+    LatLon getLatLonById(Integer id);
+
+}

--- a/src/main/java/com/clueride/domain/location/latlon/LatLonStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/latlon/LatLonStoreJpa.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/10/17.
+ */
+package com.clueride.domain.location.latlon;
+
+import java.io.IOException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * JPA implementation of the Loc LatLon Store.
+ */
+public class LatLonStoreJpa implements LatLonStore {
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public Integer addNew(LatLon latLon) throws IOException {
+        entityManager.getTransaction().begin();
+        entityManager.persist(latLon);
+        entityManager.getTransaction().commit();
+        return latLon.getId();
+    }
+
+    @Override
+    public LatLon getLatLonById(Integer id) {
+        entityManager.getTransaction().begin();
+        LatLon latLon = entityManager.find(LatLon.class, id);
+        entityManager.getTransaction().commit();
+        return latLon;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/location/latlon/README.md
+++ b/src/main/java/com/clueride/domain/location/latlon/README.md
@@ -1,0 +1,16 @@
+# Proposed (User-facing) Nodes
+
+Generally, a Node is the end-point of a Segment which is connected 
+to the network. However, when proposing new Locations which may not
+yet be connected to the network, we need a "latLon" holding the lat/lon
+pair so we know where the Location is.  The idea is we'll expand the
+network to contain the latLon/location which puts the proposed Location
+on the network.
+
+The `user.latLon` package holds the service/DAO for storing these 
+proposed Nodes in support of a Location into the database. It 
+supports the NodeService for proposed nodes.
+
+Once the latLon is on the network, it is likely the Node will be 
+persisted in the locations.geojson covered by the NodeStoreJson 
+instead of the one found here.

--- a/src/main/java/com/clueride/domain/location/loctype/LocationType.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationType.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/4/17.
+ */
+package com.clueride.domain.location.loctype;
+
+import javax.annotation.concurrent.Immutable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Domain object that can be persisted, but generally is read-only.
+ */
+@Immutable
+public class LocationType {
+    private Integer id;
+    private String name;
+    private String description;
+    private String icon;
+
+    // TODO: Temporary constructor in service of JSON
+    public LocationType() {}
+
+    private LocationType(Builder builder) {
+        this.id = builder.getId();
+        this.name = builder.getName();
+        this.description = builder.getDescription();
+        this.icon = builder.getIcon();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="location_type")
+    public static final class Builder {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="location_type_pk_sequence")
+        @SequenceGenerator(name="location_type_pk_sequence", sequenceName="location_type_id_seq", allocationSize=1)
+        private Integer id;
+
+        private String name;
+        private String icon;
+        private String description;
+
+        /**
+         * Generate instance from Builder's values.
+         * @return instance of LocationType based on Builder's values.
+         */
+        public LocationType build() {
+            return new LocationType(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Creates Builder from a given instance of LocationType.
+         * @param locationType the instance whose data to use.
+         * @return Mutable instance of the Builder for the Location Type.
+         */
+        public static Builder from(LocationType locationType) {
+            return builder()
+                    .withId(locationType.getId())
+                    .withName(locationType.getName())
+                    .withDescription(locationType.getDescription())
+                    .withIcon(locationType.getIcon())
+                    ;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public String getIcon() {
+            return icon;
+        }
+
+        public Builder withIcon(String icon) {
+            this.icon = icon;
+            return this;
+        }
+
+    }
+}

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeService.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/4/17.
+ */
+package com.clueride.domain.location.loctype;
+
+import java.util.List;
+
+/**
+ * Defines operations on Location Type instances.
+ */
+public interface LocationTypeService {
+    /**
+     * Returns (possibly cached) list of all Location Types.
+     * @return List of LocationType.
+     */
+    List<LocationType> getLocationTypes();
+
+    /**
+     * Returns the matching Location Type given the name of the Type shown to users.
+     * @param locationTypeName String that the user recognizes.
+     * @return Fully-populated instance of Location Type matching the name.
+     */
+    LocationType getByName(String locationTypeName);
+
+    /**
+     * Returns the matching Location Type given the ID of the Type.
+     * @param locationTypeId ID stored in the Location instance.
+     * @return Fully-populated instance of Location Type matching the ID.
+     */
+    LocationType getById(Integer locationTypeId);
+
+}

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeServiceImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/4/17.
+ */
+package com.clueride.domain.location.loctype;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+
+/**
+ * Service layer for Location Types.
+ * Cacheing would occur at this layer.
+ */
+public class LocationTypeServiceImpl implements LocationTypeService {
+    private final LocationTypeStore locationTypeStore;
+
+    @Inject
+    public LocationTypeServiceImpl(LocationTypeStore locationTypeStore) {
+        this.locationTypeStore = locationTypeStore;
+    }
+
+    @Override
+    public List<LocationType> getLocationTypes() {
+        return locationTypeStore.getLocationTypes();
+    }
+
+    @Override
+    public LocationType getByName(String locationTypeName) {
+        return locationTypeStore.getLocationTypeByName(locationTypeName);
+    }
+
+    @Override
+    public LocationType getById(Integer locationTypeId) {
+        return locationTypeStore.getLocationTypeById(locationTypeId);
+    }
+}

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeStore.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeStore.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/4/17.
+ */
+package com.clueride.domain.location.loctype;
+
+import java.util.List;
+
+/**
+ * Defines methods for querying Location Type instances.
+ */
+public interface LocationTypeStore {
+    /**
+     * Reads the entire list of Location Types from the database.
+     * @return List of Location Type.
+     */
+    List<LocationType> getLocationTypes();
+
+    /**
+     * Queries to find the matching Location Type by name.
+     * @param locationTypeName String that the user recognizes.
+     * @return LocationType matching the name.
+     */
+    LocationType getLocationTypeByName(String locationTypeName);
+
+    /**
+     * Queries to find the matching Location Type by ID.
+     * @param locationTypeId unique identifier for the Location Type.
+     * @return LocationType matching the ID.
+     */
+    LocationType getLocationTypeById(Integer locationTypeId);
+
+}

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeStoreJpa.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/4/17.
+ */
+package com.clueride.domain.location.loctype;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * JPA implementation of the LocationTypeStore (DAO).
+ */
+public class LocationTypeStoreJpa implements LocationTypeStore {
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public List<LocationType> getLocationTypes() {
+        List<LocationType> locationTypes = new ArrayList<>();
+        entityManager.getTransaction().begin();
+        List<LocationType.Builder> locTypeBuilders =
+                entityManager.createQuery(
+                        "SELECT lt from location_type lt"
+                ).getResultList();
+
+        for (LocationType.Builder locTypeBuilder : locTypeBuilders) {
+            locationTypes.add(locTypeBuilder.build());
+        }
+        entityManager.getTransaction().commit();
+        return locationTypes;
+    }
+
+    @Override
+    public LocationType getLocationTypeByName(String locationTypeName) {
+        entityManager.getTransaction().begin();
+
+        List<LocationType.Builder> builders = entityManager.createQuery(
+                "SELECT lt FROM location_type lt WHERE lt.name = :locTypeName"
+        ).setParameter("locTypeName", locationTypeName)
+                .getResultList();
+        entityManager.getTransaction().commit();
+
+        if (builders.size() == 1) {
+            return builders.get(0).build();
+        } else {
+            throw new RuntimeException("Multiple records found for location type name: " + locationTypeName );
+        }
+    }
+
+    @Override
+    public LocationType getLocationTypeById(Integer locationTypeId) {
+        entityManager.getTransaction().begin();
+        LocationType locationType = entityManager.find(
+                LocationType.Builder.class,
+                locationTypeId
+        ).build();
+        entityManager.getTransaction().commit();
+        return locationType;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/Outing.java
+++ b/src/main/java/com/clueride/domain/outing/Outing.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/5/16.
+ */
+package com.clueride.domain.outing;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+import com.clueride.domain.course.Course;
+import com.clueride.domain.team.Team;
+
+/**
+ * Model for the Outing: a particular {@link Team} running a particular {@link Course}
+ * at a scheduled time.
+ */
+public class Outing {
+    private final Integer id;
+    private Integer teamId;
+    private Integer courseId;
+    private Date scheduledTime;
+    private Integer guideMemberId;
+
+    public Outing(Builder builder) {
+        this.id = builder.id;
+        this.teamId = builder.getTeamId();
+        this.courseId = builder.getCourseId();
+        this.scheduledTime = builder.getScheduledTime();
+        this.guideMemberId = builder.getGuideMemberId();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Integer getTeamId() {
+        return teamId;
+    }
+
+    public Integer getCourseId() {
+        return courseId;
+    }
+
+    public Date getScheduledTime() {
+        return scheduledTime;
+    }
+
+    public void setScheduledTime(Date scheduledTime) {
+        this.scheduledTime = scheduledTime;
+    }
+
+    public Integer getGuideMemberId() {
+        return guideMemberId;
+    }
+
+    @Entity(name="outing")
+    public static final class Builder {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="outing_pk_sequence")
+        @SequenceGenerator(name="outing_pk_sequence",sequenceName="outing_id_seq", allocationSize=1)
+        private Integer id;
+
+        @Column(name="team_id") private Integer teamId;
+        @Column(name="course_id") private Integer courseId;
+        @Column(name="scheduled_time") private Date scheduledTime;
+        @Column(name="guide_id") private Integer guideMemberId;
+
+        /**
+         * Builder pattern implements interface to allow construction of a given type.
+         */
+        /* For other users of an Outing. */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(Outing outing) {
+            return builder()
+                    .withId(outing.getId())
+                    .withTeamId(outing.getTeamId())
+                    .withCourseId(outing.getCourseId());
+        }
+
+        public Outing build() {
+            if (scheduledTime == null) {
+                scheduledTime = new Date();
+            }
+            return new Outing(this);
+        }
+
+        public Integer getCourseId() {
+            return courseId;
+        }
+
+        public Builder withCourseId(Integer courseId) {
+            this.courseId = courseId;
+            return this;
+        }
+
+        public Integer getTeamId() {
+            return teamId;
+        }
+
+        public Builder withTeamId(Integer teamId) {
+            this.teamId = teamId;
+            return this;
+        }
+
+        /* ID is interesting because it can pick-up from a new instance (assigned), or have been persisted for existing
+         * instances. */
+        public Integer getId() {
+            return id;
+        }
+
+        /* Also for Jackson when accepting a fully-populated Outing (ID already assigned). */
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public Date getScheduledTime() {
+            return scheduledTime;
+        }
+
+        public Builder withScheduledTime(Date scheduledTime) {
+            this.scheduledTime = scheduledTime;
+            return this;
+        }
+
+        public Integer getGuideMemberId() {
+            return guideMemberId;
+        }
+
+        public Builder withGuideMemberId(Integer guideMemberId) {
+            this.guideMemberId = guideMemberId;
+            return this;
+        }
+
+    }
+}

--- a/src/main/java/com/clueride/domain/outing/OutingService.java
+++ b/src/main/java/com/clueride/domain/outing/OutingService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.outing;
+
+/**
+ * Defines operations on an Outing.
+ */
+public interface OutingService {
+    /**
+     * Given an ID, retrieve the Outing identified by that ID.
+     * @param outingId Unique integer representing the Outing.
+     * @return Matching Outing.
+     */
+    Outing getById(Integer outingId);
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
+++ b/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.outing;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+/**
+ * Implementation of OutingService.
+ */
+public class OutingServiceImpl implements OutingService {
+    @Inject
+    private Logger LOGGER;
+
+    @Inject
+    private OutingStore outingStore;
+
+    @Override
+    public Outing getById(Integer outingId) {
+        LOGGER.info("Retrieving outing for ID: {}", outingId);
+        return outingStore.getOutingById(outingId).build();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingStore.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStore.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/5/16.
+ */
+package com.clueride.domain.outing;
+
+import java.io.IOException;
+
+/**
+ * Persistence interface for {@link Outing} instances.
+ */
+public interface OutingStore {
+    /**
+     * Accepts fully-populated Outing instance and returns the ID of a newly persisted record.
+     *
+     * @param builder - {@link Outing.Builder} instance which is fully-populated.
+     * @return Integer DB-generated ID.
+     * @throws IOException when there is trouble writing to the store.
+     */
+    Integer addNew(Outing.Builder builder) throws IOException;
+
+    /**
+     * Given a specific Outing Identifier, return the matching {@link Outing} instance.
+     * @param outingId - Integer ID for the Outing.
+     * @return Matching Outing.
+     */
+    Outing.Builder getOutingById(Integer outingId);
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.outing;
+
+import java.io.IOException;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * JPA-based implementation of OutingStore.
+ */
+public class OutingStoreJpa implements OutingStore {
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public Integer addNew(Outing.Builder builder) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Outing.Builder getOutingById(Integer outingId) {
+        return entityManager.find(Outing.Builder.class, outingId);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingWebService.java
+++ b/src/main/java/com/clueride/domain/outing/OutingWebService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.outing;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.clueride.auth.Secured;
+
+/**
+ * REST API for Outings.
+ */
+@Path("/outing")
+public class OutingWebService {
+    @Inject
+    private OutingService outingService;
+
+    @GET
+    @Secured
+    @Path("{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Outing getOutingById(@PathParam("id") Integer outingId) {
+        return outingService.getById(outingId);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/path/Path.java
+++ b/src/main/java/com/clueride/domain/path/Path.java
@@ -1,0 +1,79 @@
+/**
+ *   Copyright 2015 Jett Marks
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created Oct 20, 2015
+ */
+package com.clueride.domain.path;
+
+import java.util.List;
+
+import com.clueride.domain.course.Step;
+import com.clueride.domain.location.Location;
+
+/**
+ * Represents a particular choice of Segments to travel between two
+ * {@link Location}s.
+ *
+ * Also holds
+ * <ul>
+ *     <li>List of Edge IDs</li>
+ *     <li>Node ID of Departure</li>
+ *     <li>Node ID of Destination</li>
+ * </ul>
+ *
+ * @author jett
+ */
+public interface Path extends Step {
+    // TODO: Unsure who is using this, but commented out to avoid bringing this code in right now.
+//    SortedSet<Segment> getSegments();
+
+    /**
+     * Uniquely identifies this particular sequence of segments/edges between
+     * two nodes.
+     * @return Integer representing this Path.
+     */
+    Integer getId();
+
+    /**
+     * ID of the Node at the start of this Path; the Departure.
+     * @return Integer representing the point of departure.
+     */
+    Integer getStartNodeId();
+
+    /**
+     * ID of the Node at the end of this Path; the Destination.
+     * @return Integer representing the destination point.
+     */
+    Integer getEndNodeId();
+
+    /**
+     * Retrieves ordered List of IDs for the Edges.
+     * @return ordered List of Edges.
+     */
+    List<Integer> getEdgeIds();
+
+    /**
+     * ID of the departure Location.
+     * @return unique Integer representing the Departure Location.
+     */
+    Integer getStartLocationId();
+
+    /**
+     * ID of the Destination Location.
+     * @return unique Integer representing the Destination Location.
+     */
+    Integer getEndLocationId();
+
+}

--- a/src/main/java/com/clueride/domain/path/PathService.java
+++ b/src/main/java/com/clueride/domain/path/PathService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/12/17.
+ */
+package com.clueride.domain.path;
+
+import java.util.List;
+
+/**
+ * Defines operations on Paths.
+ */
+public interface PathService {
+    /**
+     * Given an ID, retrieve the Path instance matching the ID.
+     * @param id unique identifier for the Path.
+     * @return fully-populated Path instance matching the ID.
+     */
+    Path getById(Integer id);
+
+    /**
+     * Retrieve all Paths available to the system.
+     * @return List of all Paths.
+     */
+    List<Path> getAll();
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/Puzzle.java
+++ b/src/main/java/com/clueride/domain/puzzle/Puzzle.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2015 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/23/15.
+ */
+package com.clueride.domain.puzzle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.clueride.domain.puzzle.answer.Answer;
+import com.clueride.domain.puzzle.answer.AnswerKey;
+import com.clueride.domain.location.Location;
+
+@Immutable
+public class Puzzle {
+    private Integer id;
+    private String name;
+    private String locationName;
+    private String question;
+    private List<Answer> answers = new ArrayList<>();
+    private AnswerKey correctAnswer;
+    private Integer points;
+
+    private Puzzle(Builder builder) {
+        this.id = builder.getId();
+        this.name = builder.getName();
+        this.locationName = builder.getLocationBuilder().getName();
+        this.question = builder.getQuestion();
+        this.answers = builder.getAnswers();
+        this.correctAnswer = builder.getCorrectAnswer();
+        this.points = builder.getPoints();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLocationName() {
+        return locationName;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public AnswerKey getCorrectAnswer() {
+        return correctAnswer;
+    }
+
+    public Integer getPoints() {
+        return points;
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="PuzzleBuilder")
+    @Table(name = "puzzle")
+    public static final class Builder {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="puzzle_pk_sequence")
+        @SequenceGenerator(name="puzzle_pk_sequence",sequenceName="puzzle_id_seq", allocationSize=1)
+        private Integer id;
+
+        private String name;
+        private String question;
+
+        @OneToMany(
+                fetch = FetchType.LAZY,
+                cascade = CascadeType.ALL,
+                mappedBy = "puzzleBuilder"
+        )
+        private List<Answer> answers = new ArrayList<>();
+
+        @Column(name = "correct_answer") private AnswerKey correctAnswer;
+        private Integer points;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "location_id")
+        private Location.Builder locationBuilder;
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(Puzzle instance) {
+            return builder()
+                    .withId(instance.id)
+                    .withName(instance.name)
+                    .withQuestion(instance.question)
+                    .withCorrectAnswer(instance.correctAnswer)
+                    .withAnswers(instance.answers)
+                    .withPoints(instance.points)
+                    ;
+        }
+
+        public String getQuestion() {
+            return question;
+        }
+
+        public Builder withQuestion(String question) {
+            this.question = question;
+            return this;
+        }
+
+        public List<Answer> getAnswers() {
+            return answers;
+        }
+
+        public Builder withAnswers(List<Answer> answers) {
+            this.answers = answers;
+            return this;
+        }
+
+        public AnswerKey getCorrectAnswer() {
+            return correctAnswer;
+        }
+
+        public Builder withCorrectAnswer(AnswerKey correctAnswer) {
+            this.correctAnswer = correctAnswer;
+            return this;
+        }
+
+        public Integer getPoints() {
+            return points;
+        }
+
+        public Builder withPoints(Integer points) {
+            this.points = points;
+            return this;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withLocationBuilder(Location.Builder locationBuilder) {
+            this.locationBuilder = locationBuilder;
+            return this;
+        }
+
+        public Location.Builder getLocationBuilder() {
+            return locationBuilder;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Puzzle build() {
+            return new Puzzle(this);
+        }
+
+        public Builder setId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setQuestion(String question) {
+            this.question = question;
+            return this;
+        }
+
+        public Builder setAnswers(List<Answer> answers) {
+            this.answers = answers;
+            return this;
+        }
+
+        public Builder setCorrectAnswer(AnswerKey correctAnswer) {
+            this.correctAnswer = correctAnswer;
+            return this;
+        }
+
+        public Builder setPoints(Integer points) {
+            this.points = points;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return EqualsBuilder.reflectionEquals(this, obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+}

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/22/17.
+ */
+package com.clueride.domain.puzzle;
+
+import java.util.List;
+
+import com.clueride.domain.location.Location;
+
+/**
+ * Defines the operations on a Puzzle.
+ */
+public interface PuzzleService {
+    /**
+     * Given the unique ID of a Puzzle, return the full instance.
+     * @param id unique ID for the puzzle.
+     * @return matching Puzzle instance.
+     */
+    Puzzle getById(Integer id);
+
+    /**
+     * Given a Location ID, find the Puzzles associated with that Location.
+     * @param locationId unique identifier for a Location.
+     * @return list of Puzzles for the location.
+     */
+    List<Puzzle> getByLocation(Integer locationId);
+
+    /**
+     * Create a New puzzle instance for the given Location.
+     * @param puzzleBuilder data for the new Puzzle.
+     * @param locationBuilder data for the Location to accept the new Puzzle.
+     * @return fully-populated instance of the new Puzzle.
+     */
+    Puzzle addNew(Puzzle.Builder puzzleBuilder, Location.Builder locationBuilder);
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleServiceImpl.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleServiceImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/22/17.
+ */
+package com.clueride.domain.puzzle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+import com.clueride.domain.location.Location;
+
+/**
+ * Implementation of the PuzzleService interface.
+ */
+public class PuzzleServiceImpl implements PuzzleService {
+    @Inject
+    private Logger LOGGER;
+
+    private final PuzzleStore puzzleStore;
+
+    @Inject
+    public PuzzleServiceImpl(PuzzleStore puzzleStore) {
+        this.puzzleStore = puzzleStore;
+    }
+
+    @Override
+    public Puzzle getById(Integer id) {
+        return puzzleStore.getPuzzleById(id).build();
+    }
+
+    @Override
+    public List<Puzzle> getByLocation(Integer locationId) {
+        List<Puzzle> puzzles = new ArrayList<>();
+        Location.Builder locationBuilder = Location.Builder.builder().withId(locationId);
+        for (Puzzle.Builder puzzleBuilder : puzzleStore.getPuzzlesForLocation(locationBuilder)) {
+            try {
+                puzzles.add(puzzleBuilder.build());
+            } catch (IllegalStateException ise) {
+                LOGGER.warn("Problem building puzzle from DB record: ", ise);
+                // Continue retrieving remaining records
+            }
+        }
+        return puzzles;
+    }
+
+    @Override
+    public Puzzle addNew(Puzzle.Builder puzzleBuilder, Location.Builder locationBuilder) {
+        return null;
+    }
+}

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleStore.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleStore.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/19/17.
+ */
+package com.clueride.domain.puzzle;
+
+import java.util.List;
+
+import com.clueride.domain.location.Location;
+
+/**
+ * Definition of operations on Puzzle records.
+ */
+public interface PuzzleStore {
+    /**
+     * Accepts a Puzzle.Builder (including the Answers) and persists
+     * as a new Puzzle record. The Puzzle Builder needs to have its
+     * Location set so it can be attached to that Location.
+     * @param puzzleBuilder fully-populated instance of Puzzle as a Builder.
+     * @return unique ID for this new Puzzle instance.
+     */
+    Integer addNew(Puzzle.Builder puzzleBuilder);
+
+    Puzzle.Builder getPuzzleById(Integer id);
+
+    /**
+     * Given a Location ID, retrieve all Puzzles for that location.
+     *
+     * @param locationBuilder@return (possibly empty) list of Puzzles for the Location.
+     */
+    List<Puzzle.Builder> getPuzzlesForLocation(Location.Builder locationBuilder);
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/19/17.
+ */
+package com.clueride.domain.puzzle;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import com.clueride.domain.location.Location;
+
+/**
+ * Implementation of the Puzzle Store.
+ */
+public class PuzzleStoreJpa implements PuzzleStore {
+
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public Integer addNew(Puzzle.Builder puzzleBuilder) {
+        entityManager.getTransaction().begin();
+        entityManager.persist(puzzleBuilder);
+        entityManager.getTransaction().commit();
+        return puzzleBuilder.getId();
+    }
+
+    @Override
+    public Puzzle.Builder getPuzzleById(Integer id) {
+        Puzzle.Builder puzzleBuilder;
+        entityManager.getTransaction().begin();
+        puzzleBuilder = entityManager.find(Puzzle.Builder.class, id);
+        entityManager.getTransaction().commit();
+        return puzzleBuilder;
+    }
+
+    @Override
+    public List<Puzzle.Builder> getPuzzlesForLocation(Location.Builder locationBuilder) {
+        List<Puzzle.Builder> puzzleBuilders;
+        entityManager.getTransaction().begin();
+        puzzleBuilders = entityManager.createQuery(
+                        "SELECT p FROM PuzzleBuilder p where p.locationBuilder = :locationBuilder"
+                ).setParameter("locationBuilder", locationBuilder)
+                .getResultList();
+        entityManager.getTransaction().commit();
+        return puzzleBuilders;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/answer/Answer.java
+++ b/src/main/java/com/clueride/domain/puzzle/answer/Answer.java
@@ -1,0 +1,116 @@
+package com.clueride.domain.puzzle.answer;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.clueride.domain.puzzle.Puzzle;
+
+/**
+ * Copyright 2015 Jett Marks
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p/>
+ * Created by jett on 11/23/15.
+ */
+@Entity(name = "Answer")
+@Table(name = "answer")
+public class Answer {
+    @Id
+    @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="answer_pk_sequence")
+    @SequenceGenerator(name="answer_pk_sequence",sequenceName="answer_id_seq", allocationSize=1)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "puzzle_id")
+    private Puzzle.Builder puzzleBuilder;
+
+    @Column(name = "answer_key") private AnswerKey answerKey;
+    @Column(name = "answer") private String answer;
+
+    public Answer() {}
+
+    public Answer(AnswerKey answerKey, String answer) {
+        this.answerKey = answerKey;
+        this.answer = answer;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Answer withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public AnswerKey getKey() {
+        return answerKey;
+    }
+
+    public Answer setKey(AnswerKey answerKey) {
+        this.answerKey = answerKey;
+        return this;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public Answer setAnswer(String answer) {
+        this.answer = answer;
+        return this;
+    }
+
+    public Answer withPuzzleBuilder(Puzzle.Builder puzzleBuilder) {
+        this.puzzleBuilder = puzzleBuilder;
+        return this;
+    }
+
+    public Answer withAnswerKey(AnswerKey answerKey) {
+        this.answerKey = answerKey;
+        return this;
+    }
+
+    public Answer withAnswer(String answer) {
+        this.answer = answer;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/answer/AnswerKey.java
+++ b/src/main/java/com/clueride/domain/puzzle/answer/AnswerKey.java
@@ -1,0 +1,26 @@
+package com.clueride.domain.puzzle.answer;
+
+/**
+ * Copyright 2015 Jett Marks
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p/>
+ * Created by jett on 11/23/15.
+ */
+public enum AnswerKey {
+    A,
+    B,
+    C,
+    D,
+    E
+}

--- a/src/main/java/com/clueride/domain/team/Team.java
+++ b/src/main/java/com/clueride/domain/team/Team.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2015 Jett Marks
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p/>
+ * Created 11/17/15.
+ */
+package com.clueride.domain.team;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.clueride.domain.account.member.Member;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class Team {
+    private final Integer id;
+    private final String name;
+    private final List<Member> members;
+
+    public Team(Builder builder) {
+        this.id = requireNonNull(builder.getId());
+        this.name = requireNonNull(builder.getName());
+        this.members = requireNonNull(builder.getMembers());
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public void add(Member member) {
+        members.add(member);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="teamBuilder")
+    @Table(name="team")
+    public static final class Builder {
+        @Id
+        @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="team_pk_sequence")
+        @SequenceGenerator(name="team_pk_sequence",sequenceName="team_id_seq", allocationSize = 1)
+        private Integer id;
+
+        private String name;
+
+        @ManyToMany(cascade = CascadeType.ALL)
+        @JoinTable(
+                name="team_membership",
+                joinColumns = {@JoinColumn(name="team_id")},
+                inverseJoinColumns = {@JoinColumn(name="member_id")}
+        )
+        private Set<Member.Builder> memberBuilders = new HashSet<>();
+
+        /* Allows Jackson to construct. */
+        public Builder() {}
+
+        /* Normal pattern for constructing a Builder. */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Team build() {
+            return new Team(this);
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public List<Member> getMembers() {
+            List<Member> members = new ArrayList<>();
+            for (Member.Builder builder: memberBuilders) {
+                members.add(builder.build());
+            }
+            return members;
+        }
+
+        public Builder withMembers(Set<Member.Builder> memberBuilders) {
+            this.memberBuilders = memberBuilders;
+            return this;
+        }
+
+        public Builder withNewMember(Member newMember) {
+            this.memberBuilders.add(Member.Builder.from(newMember));
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/clueride/domain/team/TeamService.java
+++ b/src/main/java/com/clueride/domain/team/TeamService.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015 Jett Marks
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p/>
+ * Created 11/17/15.
+ */
+package com.clueride.domain.team;
+
+import java.util.List;
+
+import com.clueride.domain.account.member.Member;
+
+public interface TeamService {
+
+    /**
+     * Returns all of our teams.
+     * @return List of all Teams.
+     */
+    List<Team> getTeams();
+
+    /**
+     * Given the ID, return the matching Team.
+     * @param teamId unique identifier for the Team.
+     * @return Matching Team.
+     */
+    Team getTeam(Integer teamId);
+
+    /**
+     * Given the Team ID and a new Member instance, add the player to the team and
+     * return the updated team.
+     * @param teamId - Unique ID of the Team.
+     * @param newMember - New fully-populated instance of a Member object.
+     * @return the updated Team.
+     */
+    Team addMember(Integer teamId, Member newMember);
+
+    /**
+     * Given a name for a new team, create the Team record so we can then add
+     * members.
+     * @param name String representing the name of the team.
+     * @return Named Team ready to add members (none included).
+     */
+    Team newTeam(String name);
+
+}

--- a/src/main/java/com/clueride/domain/team/TeamServiceImpl.java
+++ b/src/main/java/com/clueride/domain/team/TeamServiceImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 3/20/16.
+ */
+package com.clueride.domain.team;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+import com.clueride.domain.account.member.Member;
+import com.clueride.domain.account.member.MemberService;
+
+/**
+ * Implementation of the Team Interface for maintaining the list of Teams and their members.
+ */
+public class TeamServiceImpl implements TeamService {
+    @Inject
+    private Logger LOGGER;
+
+    private final TeamStore teamStore;
+    private final MemberService memberService;
+
+    @Inject
+    public TeamServiceImpl(
+            TeamStore teamStore,
+            MemberService memberService
+    ) {
+        this.teamStore = teamStore;
+        this.memberService = memberService;
+    }
+
+
+    @Override
+    public List<Team> getTeams() {
+        List<Team> teams = new ArrayList<>();
+        List<Team.Builder> builders = teamStore.getTeams();
+        for (Team.Builder builder : builders) {
+            teams.add(builder.build());
+        }
+        return teams;
+    }
+
+    @Override
+    public Team getTeam(Integer teamId) {
+        return teamStore.getTeamById(teamId).build();
+    }
+
+    @Override
+    public Team addMember(Integer teamId, Member newMember) {
+        Member member = memberService.getMember(newMember.getId());
+        LOGGER.info("Adding Member " + member.getDisplayName() + " to team " + teamId);
+        Team.Builder teamBuilder = teamStore.getTeamById(teamId);
+        teamBuilder.withNewMember(member);
+        return teamStore.updateTeam(teamBuilder).build();
+    }
+
+    @Override
+    public Team newTeam(String name) {
+        Team.Builder teamBuilder = Team.Builder.builder()
+                .withName(name);
+        return teamStore.addNew(teamBuilder).build();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/team/TeamStore.java
+++ b/src/main/java/com/clueride/domain/team/TeamStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/31/18.
+ */
+package com.clueride.domain.team;
+
+import java.util.List;
+
+/**
+ * How we persist Teams and their members.
+ */
+public interface TeamStore {
+
+    /**
+     * Persist a new Team.
+     * @param builder Builder instance representing the Team including the Members of the Team.
+     * @return ID of the new Team.
+     */
+    Team.Builder addNew(Team.Builder builder);
+
+    /**
+     * Retrieve a list of the current Teams.
+     * @return All Teams.
+     */
+    List<Team.Builder> getTeams();
+
+    /**
+     * REtrieve the Team matching the given ID.
+     * @param teamId Unique identifier for the team.
+     * @return Team.Builder instance matching the given ID.
+     */
+    Team.Builder getTeamById(Integer teamId);
+
+    /**
+     * Merge changes to the list of members (or name) for an existing Team.
+     * @param teamBuilder Team Builder instance with updated information (members or name).
+     * @return updated instance.
+     */
+    Team.Builder updateTeam(Team.Builder teamBuilder);
+
+}

--- a/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
+++ b/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/31/18.
+ */
+package com.clueride.domain.team;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.slf4j.Logger;
+
+/**
+ * JPA implementation of {@link TeamStore}.
+ */
+public class TeamStoreJpa implements TeamStore {
+    @Inject
+    private Logger LOGGER;
+
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public Team.Builder addNew(Team.Builder teamBuilder) {
+        LOGGER.info("Creating a new Team: " + teamBuilder.getName());
+        entityManager.getTransaction().begin();
+        entityManager.persist(teamBuilder);
+        entityManager.getTransaction().commit();
+        return teamBuilder;
+    }
+
+    @Override
+    public List<Team.Builder> getTeams() {
+        LOGGER.info("Retrieving full list of Teams");
+        entityManager.getTransaction().begin();
+        List<Team.Builder> builders = entityManager.createQuery("SELECT t FROM teamBuilder t").getResultList();
+        entityManager.getTransaction().commit();
+        return builders;
+    }
+
+    @Override
+    public Team.Builder getTeamById(Integer teamId) {
+        LOGGER.info("Retrieving Team by ID: " + teamId);
+        entityManager.getTransaction().begin();
+        Team.Builder builder = entityManager.find(Team.Builder.class, teamId);
+        entityManager.getTransaction().commit();
+        return builder;
+    }
+
+    @Override
+    public Team.Builder updateTeam(Team.Builder teamBuilder) {
+        LOGGER.info("Updating an existing Team: " + teamBuilder.getId());
+        entityManager.getTransaction().begin();
+        entityManager.merge(teamBuilder);
+        entityManager.getTransaction().commit();
+        return teamBuilder;
+    }
+
+}


### PR DESCRIPTION
Well, this brought over the Course, and that brought in a ton of other stuff:
- Adds full suite for skeletal Outing.
- Adds DTO, Service and Store for Course.
- Adds DTO and Service for GameState along with supporting SSEvent package.
- Adds DTO, Service and Store for Location along with supporting packages
for LocationType and LatLon.
- Adds DTO and Service for Path (this is an older implementation)
- Adds DTO, Service and Store for Puzzle along with supporting Answer package.
- Adds DTO, Service and Store for Team.

This also adds another method to the MemberService for retrieving a Member
record by ID.

Missing:
- Test code
- REST API in some instances
- TeamMembership class/package.