### PR TITLE
CA-412 Create Invite View with specific items needed for List Display…

### DIFF
--- a/src/main/java/com/clueride/domain/course/Course.java
+++ b/src/main/java/com/clueride/domain/course/Course.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.course;
 
+import java.net.URL;
 import java.util.List;
 
 import com.clueride.domain.location.Location;
@@ -30,6 +31,7 @@ public interface Course {
     Integer getId();
     String getName();
     String getDescription();
+    URL getUrl();
     Integer getCourseTypeId();
     List<Step> getSteps();
     List<Integer> getPathIds();

--- a/src/main/java/com/clueride/domain/course/CourseService.java
+++ b/src/main/java/com/clueride/domain/course/CourseService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.course;
+
+/**
+ * Defines operations on a Course.
+ */
+public interface CourseService {
+    /**
+     * Interim retrieval of a Course instance matching the given ID.
+     * @param courseId unique identifier for the course.
+     * @return matching Course.
+     */
+    Course getById(Integer courseId);
+
+}

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/19.
+ */
+package com.clueride.domain.course;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import com.clueride.domain.location.Location;
+
+/**
+ * Interim implementation.
+ */
+public class CourseServiceImpl implements CourseService {
+    @Override
+    public Course getById(final Integer courseId) {
+        /* Interim implementation. */
+        return new Course(){
+
+            @Override
+            public Integer getId() {
+                return courseId;
+            }
+
+            @Override
+            public String getName() {
+                return "Five Free Things";
+            }
+
+            @Override
+            public String getDescription() {
+                return "From an article that I can no longer find";
+            }
+
+            @Override
+            public Integer getCourseTypeId() {
+                return null;
+            }
+
+            @Override
+            public List<Step> getSteps() {
+                return Collections.EMPTY_LIST;
+            }
+
+            @Override
+            public List<Integer> getPathIds() {
+                return Collections.EMPTY_LIST;
+            }
+
+            @Override
+            public Location getDeparture() {
+                return null;
+            }
+
+            @Override
+            public Location getDestination() {
+                return null;
+            }
+
+            @Override
+            public URL getUrl() {
+                URL url = null;
+                try {
+                    url = new URL("https://clueride.com/five-free-things/");
+                } catch (MalformedURLException e) {
+                    e.printStackTrace();
+                }
+                return url;
+            }
+
+        };
+
+    }
+
+}

--- a/src/main/java/com/clueride/domain/course/GameCourse.java
+++ b/src/main/java/com/clueride/domain/course/GameCourse.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.course;
 
+import java.net.URL;
 import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
@@ -68,6 +69,11 @@ public class GameCourse implements Course {
 
     @Override
     public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public URL getUrl() {
         return null;
     }
 

--- a/src/main/java/com/clueride/domain/invite/Invite.java
+++ b/src/main/java/com/clueride/domain/invite/Invite.java
@@ -17,6 +17,9 @@
  */
 package com.clueride.domain.invite;
 
+import java.net.URL;
+import java.util.Date;
+
 import javax.annotation.concurrent.Immutable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,11 +41,17 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 @Immutable
 public class Invite {
-    private String token;
     private Integer memberId;
     private Integer outingId;
     private Integer id = null;
     private InviteState state;
+
+    /* Derived Fields */
+    private String guideName;
+    private String teamName;
+    private String courseName;
+    private URL courseUrl;
+    private Date scheduledTime;
 
     /**
      * Builds immutable instance of Invite from Builder instance.
@@ -50,15 +59,15 @@ public class Invite {
      * @param builder - Builder with all the data needed to construct Invite instance.
      */
     public Invite(Builder builder) {
-        this.token = builder.getToken();
         this.id = builder.getId();
         this.outingId = builder.getOutingId();
         this.memberId = builder.getMemberId();
         this.state = (builder.getState() != null) ? builder.getState() : InviteState.PROVISIONAL;
-    }
-
-    public String getToken() {
-        return token;
+        this.guideName = builder.getGuideName();
+        this.teamName = builder.getTeamName();
+        this.courseName = builder.getCourseName();
+        this.courseUrl = builder.getCourseUrl();
+        this.scheduledTime = builder.getScheduledTime();
     }
 
     public Integer getMemberId() {
@@ -73,16 +82,28 @@ public class Invite {
         return id;
     }
 
-    public void setState(InviteState state) {
-        this.state = state;
-    }
-
     public InviteState getState() {
         return state;
     }
 
-    public void setId(Integer id) {
-        this.id = id;
+    public String getGuideName() {
+        return guideName;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public URL getCourseUrl() {
+        return courseUrl;
+    }
+
+    public Date getScheduledTime() {
+        return scheduledTime;
     }
 
     @Override
@@ -104,17 +125,20 @@ public class Invite {
 
         @Column(name="member_id")
         private Integer memberId;
-        @Column(name="outing_id")       // TODO: Outing is not yet persisted in the JPA store.
+        @Column(name="outing_id")
         private Integer outingId;
-        @Column(name="team_id")         // TODO: Team is not yet persisted in the JPA store.
+        @Column(name="team_id")
         private Integer teamId;
 
         @Column(name="state")
         @Enumerated(EnumType.STRING)
         private InviteState inviteState;
 
-        @Transient
-        private String token;
+        @Transient private String guideName;
+        @Transient private String teamName;
+        @Transient private String courseName;
+        @Transient private URL courseUrl;
+        @Transient private Date scheduledTime;
 
         public static Builder builder() {
             return new Builder();
@@ -126,7 +150,12 @@ public class Invite {
                     .withOutingId(instance.getOutingId())
                     .withMemberId(instance.memberId)
                     .withState(instance.state)
-                    .withToken(instance.token);
+                    .withGuideName(instance.guideName)
+                    .withTeamName(instance.teamName)
+                    .withCourseName(instance.courseName)
+                    .withCourseUrl(instance.courseUrl)
+                    .withScheduledTime(instance.scheduledTime)
+                    ;
         }
 
         public Invite build() {
@@ -143,15 +172,6 @@ public class Invite {
 
         public Builder withMemberId(Integer memberId) {
             this.memberId = memberId;
-            return this;
-        }
-
-        public String getToken() {
-            return token;
-        }
-
-        public Builder withToken(String token) {
-            this.token = token;
             return this;
         }
 
@@ -185,6 +205,51 @@ public class Invite {
 
         public Builder withState(InviteState inviteState) {
             this.inviteState = inviteState;
+            return this;
+        }
+
+        public String getGuideName() {
+            return guideName;
+        }
+
+        public Builder withGuideName(String guideName) {
+            this.guideName = guideName;
+            return this;
+        }
+
+        public String getTeamName() {
+            return teamName;
+        }
+
+        public Builder withTeamName(String teamName) {
+            this.teamName = teamName;
+            return this;
+        }
+
+        public String getCourseName() {
+            return courseName;
+        }
+
+        public Builder withCourseName(String courseName) {
+            this.courseName = courseName;
+            return this;
+        }
+
+        public URL getCourseUrl() {
+            return courseUrl;
+        }
+
+        public Builder withCourseUrl(URL courseUrl) {
+            this.courseUrl = courseUrl;
+            return this;
+        }
+
+        public Date getScheduledTime() {
+            return scheduledTime;
+        }
+
+        public Builder withScheduledTime(Date scheduledTime) {
+            this.scheduledTime = scheduledTime;
             return this;
         }
 

--- a/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * JPA-based implementation of OutingStore.
  */
@@ -36,6 +38,7 @@ public class OutingStoreJpa implements OutingStore {
 
     @Override
     public Outing.Builder getOutingById(Integer outingId) {
+        requireNonNull(outingId, "Must specify an outing ID");
         return entityManager.find(Outing.Builder.class, outingId);
     }
 

--- a/src/main/java/com/clueride/domain/team/Team.java
+++ b/src/main/java/com/clueride/domain/team/Team.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.concurrent.Immutable;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -82,7 +83,8 @@ public class Team {
 
         private String name;
 
-        @ManyToMany(cascade = CascadeType.ALL)
+        /* Without FetchType.EAGER, transaction ended before records were pulled. */
+        @ManyToMany(cascade = CascadeType.ALL, fetch=FetchType.EAGER)
         @JoinTable(
                 name="team_membership",
                 joinColumns = {@JoinColumn(name="team_id")},

--- a/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
+++ b/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
@@ -38,36 +38,28 @@ public class TeamStoreJpa implements TeamStore {
     @Override
     public Team.Builder addNew(Team.Builder teamBuilder) {
         LOGGER.info("Creating a new Team: " + teamBuilder.getName());
-        entityManager.getTransaction().begin();
         entityManager.persist(teamBuilder);
-        entityManager.getTransaction().commit();
         return teamBuilder;
     }
 
     @Override
     public List<Team.Builder> getTeams() {
         LOGGER.info("Retrieving full list of Teams");
-        entityManager.getTransaction().begin();
         List<Team.Builder> builders = entityManager.createQuery("SELECT t FROM teamBuilder t").getResultList();
-        entityManager.getTransaction().commit();
         return builders;
     }
 
     @Override
     public Team.Builder getTeamById(Integer teamId) {
         LOGGER.info("Retrieving Team by ID: " + teamId);
-        entityManager.getTransaction().begin();
         Team.Builder builder = entityManager.find(Team.Builder.class, teamId);
-        entityManager.getTransaction().commit();
         return builder;
     }
 
     @Override
     public Team.Builder updateTeam(Team.Builder teamBuilder) {
         LOGGER.info("Updating an existing Team: " + teamBuilder.getId());
-        entityManager.getTransaction().begin();
         entityManager.merge(teamBuilder);
-        entityManager.getTransaction().commit();
         return teamBuilder;
     }
 


### PR DESCRIPTION
… of an Invite

- Adds fields to the existing Invite to cover what we need from Outing, Team, Member, and Course tables;
This is done inside the Service, but we may want (CA-376) to do this at the time we're building the Session objects.
- Adds a null check for Outing ID since we're hand-editing records at this time.
- Exercises the Team entity and store for the first time under WildFly; worked out some kinks including
the lazy fetch isn't going to work with the transaction handling that we're being provided by WildFly.
- Puts up an interim Course implementation instead of getting entangled in the Course.