### PR TITLE
Location Web Service and Supporting Cast

### DIFF
--- a/src/main/java/com/clueride/auth/ClueRideSessionDto.java
+++ b/src/main/java/com/clueride/auth/ClueRideSessionDto.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import com.clueride.auth.identity.ClueRideIdentity;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
+import com.clueride.domain.course.Course;
 import com.clueride.domain.game.GameState;
 import com.clueride.domain.invite.Invite;
 import com.clueride.domain.outing.OutingView;
@@ -35,6 +36,7 @@ public class ClueRideSessionDto implements Serializable {
     private Member member = null;
     private Invite invite = null;
     private OutingView outingView = null;
+    private Course course = null;
     private GameState gameState = null;
 
     public void setClueRideIdentity(ClueRideIdentity clueRideIdentity) {
@@ -75,6 +77,14 @@ public class ClueRideSessionDto implements Serializable {
 
     public void setOutingView(OutingView outingView) {
         this.outingView = outingView;
+    }
+
+    public Course getCourse() {
+        return this.course;
+    }
+
+    public void setCourse(Course course) {
+        this.course = course;
     }
 
     public GameState getGameState() {

--- a/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
@@ -37,6 +37,7 @@ public class BadgeStoreJpa implements BadgeStore {
 
     @Override
     public List<BadgeBuilder> getAwardedBadgesForUser(Integer userId) {
+        LOGGER.debug("Retrieving Badges for User ID {}", userId);
         List<BadgeBuilder> builderList;
         builderList = entityManager.createQuery(
                     "SELECT b FROM badge_display_per_user b WHERE b.userId = :userId"

--- a/src/main/java/com/clueride/domain/course/CourseService.java
+++ b/src/main/java/com/clueride/domain/course/CourseService.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.domain.course;
 
+import java.util.List;
+
 /**
  * Defines operations on a Course.
  */
@@ -33,4 +35,12 @@ public interface CourseService {
      * @return Session's instance of {@link Course}.
      */
     Course getSessionCourse();
+
+    /**
+     * Given the Course ID, retrieve the ordered list of Location IDs for that Course.
+     * @param courseId unique identifier for the Course.
+     * @return Ordered list of Location IDs.
+     */
+    List<Integer> getLocationIdsForCourse(Integer courseId);
+
 }

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -23,15 +23,32 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import com.clueride.domain.location.Location;
+import com.clueride.network.path.PathService;
 
 /**
  * Interim implementation.
  */
 public class CourseServiceImpl implements CourseService {
+    private final PathService pathService;
+
+    @Inject
+    public CourseServiceImpl(
+            PathService pathService
+    ) {
+        this.pathService = pathService;
+    }
+
     @Override
     public Course getSessionCourse() {
         return getById(1);
+    }
+
+    @Override
+    public List<Integer> getLocationIdsForCourse(Integer courseId) {
+        return pathService.getLocationIds(courseId);
     }
 
     @Override

--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -78,8 +78,9 @@ public class Location implements Step {
         // If we have multiple images, the ranking goes up
         imageUrls = builder.getImageUrls();
 
+        // TODO: we may want a Location that holds these, but it's not terrible to retrieve puzzles separately. */
         // If this is missing, we're at the Place level; present, we're at the Attraction level
-        puzzleBuilders = builder.getPuzzleBuilders();
+//        puzzleBuilders = builder.getPuzzleBuilders();
 
         // Featured Level requires the following
         googlePlaceId = builder.getGooglePlaceId();
@@ -121,11 +122,11 @@ public class Location implements Step {
      * @return Enumeration of the type of Location.
      */
     public Integer getLocationTypeId() {
-        return locationType.getId();
+        return (locationType == null ? 0 : locationType.getId());
     }
 
     public String getLocationTypeName() {
-        return locationType.getName();
+        return (locationType == null ? "none" : locationType.getName());
     }
 
     public LocationType getLocationType() {

--- a/src/main/java/com/clueride/domain/location/LocationBuilder.java
+++ b/src/main/java/com/clueride/domain/location/LocationBuilder.java
@@ -25,9 +25,12 @@ import java.util.Map;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
@@ -36,6 +39,7 @@ import com.google.common.base.Optional;
 
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.loctype.LocationType;
+import com.clueride.domain.location.loctype.LocationTypeBuilder;
 import com.clueride.domain.puzzle.PuzzleBuilder;
 
 /**
@@ -51,8 +55,6 @@ public class LocationBuilder {
     private String name;
     private String description;
 
-    @Column(name= "location_type_id") private Integer locationTypeId;
-
     @Column(name="node_id") private Integer nodeId;
     @Column(name="featured_image_id") private Integer featuredImageId;
 
@@ -62,6 +64,10 @@ public class LocationBuilder {
     // TODO: CA-325 - Coming out after we abandon the Json Clues
     @Transient
     private List<Integer> clueIds;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_type_id")
+    private LocationTypeBuilder locationTypeBuilder;
 
     @Transient
     private LocationType locationType;
@@ -112,8 +118,10 @@ public class LocationBuilder {
     }
 
     public Location build() {
-        if (locationType == null) {
+        if (locationTypeBuilder == null) {
             throw new IllegalStateException("Location Type cannot be null");
+        } else {
+            locationType = locationTypeBuilder.build();
         }
         return new Location(this);
     }
@@ -155,14 +163,15 @@ public class LocationBuilder {
         return locationType;
     }
 
-    public LocationBuilder withLocationTypeId(Integer locationTypeId) {
-        this.locationTypeId = locationTypeId;
-        return this;
-    }
-
-    public Integer getLocationTypeId() {
-        return locationTypeId;
-    }
+    // TODO: Undecided if we want this flattened representation or not.
+//    public LocationBuilder withLocationTypeId(Integer locationTypeId) {
+//        this.locationTypeId = locationTypeId;
+//        return this;
+//    }
+//
+//    public Integer getLocationTypeId() {
+//        return locationTypeId;
+//    }
 
     public LocationBuilder withLocationTypeName(String locationTypeName) {
         this.locationTypeName = locationTypeName;
@@ -179,8 +188,17 @@ public class LocationBuilder {
 
     public LocationBuilder withLocationType(LocationType locationType) {
         this.locationType = locationType;
-        this.locationTypeId = locationType.getId();
+//        this.locationTypeId = locationType.getId();
         return this;
+    }
+
+    public LocationTypeBuilder getLocationTypeBuilder() {
+        return locationTypeBuilder;
+    }
+
+    public void setLocationTypeBuilder(LocationTypeBuilder locationTypeBuilder) {
+        this.locationTypeBuilder = locationTypeBuilder;
+        this.locationType = locationTypeBuilder.build();
     }
 
     public LocationBuilder withReadinessLevel(ReadinessLevel readinessLevel) {
@@ -324,7 +342,7 @@ public class LocationBuilder {
                 .withId(locationBuilder.id)
                 .withDescription(locationBuilder.description)
                 .withNodeId(locationBuilder.nodeId)
-                .withLocationTypeId(locationBuilder.locationTypeId)
+//                .withLocationTypeId(locationBuilder.locationTypeId)
                 .withLocationGroupId(locationBuilder.locationGroupId)
                 .withImageUrls(locationBuilder.imageUrls);
     }
@@ -338,4 +356,5 @@ public class LocationBuilder {
         this.clueIds = clueIds;
         return this;
     }
+
 }

--- a/src/main/java/com/clueride/domain/location/LocationService.java
+++ b/src/main/java/com/clueride/domain/location/LocationService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/26/19.
+ */
+package com.clueride.domain.location;
+
+import java.util.List;
+
+import com.clueride.domain.course.Course;
+
+/**
+ * Defines operations on {@link Location} instances.
+ */
+public interface LocationService {
+
+    /**
+     * For an open session (which will have an Outing & Course),
+     * return the list of ordered Locations that support the {@link Course}.
+     * @return List of Location for the current session's Course; empty list
+     * if no session or Course is available.
+     */
+    List<Location> getSessionLocationsWithGeoJson();
+
+}

--- a/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/26/19.
+ */
+package com.clueride.domain.location;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+
+import com.clueride.auth.ClueRideSession;
+import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.domain.course.CourseService;
+import com.clueride.domain.location.latlon.LatLon;
+import com.clueride.domain.location.latlon.LatLonService;
+import com.clueride.domain.outing.OutingView;
+
+/**
+ * Implementation of {@link LocationService}.
+ */
+public class LocationServiceImpl implements LocationService {
+
+    @Inject
+    @SessionScoped
+    @ClueRideSession
+    private ClueRideSessionDto clueRideSessionDto;
+
+    private final CourseService courseService;
+    private final LocationStore locationStore;
+    private final LatLonService latLonService;
+
+    @Inject
+    public LocationServiceImpl(
+            CourseService courseService,
+            LocationStore locationStore,
+            LatLonService latLonService
+    ) {
+        this.courseService = courseService;
+        this.locationStore = locationStore;
+        this.latLonService = latLonService;
+    }
+
+    @Override
+    public List<Location> getSessionLocationsWithGeoJson() {
+        List<Location> locations = new ArrayList<>();
+        OutingView outingView = clueRideSessionDto.getOutingView();
+        List<Integer> locationIds = courseService.getLocationIdsForCourse(outingView.getCourseId());
+        for (Integer locationId : locationIds) {
+            LocationBuilder locationBuilder = locationStore.getLocationBuilderById(locationId);
+
+            // TODO: When GeoJSON out of the DB is available for Nodes, use that instead of this:
+            LatLon latLon = latLonService.getLatLonById(locationBuilder.getNodeId());
+            locationBuilder.withLatLon(latLon);
+            locations.add(locationBuilder.build());
+        }
+
+        return locations;
+    }
+}

--- a/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
@@ -59,9 +59,7 @@ public class LocationStoreJpa implements LocationStore {
 
     @Override
     public LocationBuilder getLocationBuilderById(Integer id) {
-        entityManager.getTransaction().begin();
         LocationBuilder locationBuilder = entityManager.find(LocationBuilder.class, id);
-        entityManager.getTransaction().commit();
         return locationBuilder;
     }
 

--- a/src/main/java/com/clueride/domain/location/LocationWebService.java
+++ b/src/main/java/com/clueride/domain/location/LocationWebService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/27/19.
+ */
+package com.clueride.domain.location;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.clueride.auth.Secured;
+
+/**
+ * REST API for {@link Location} instances.
+ */
+@Path("location")
+public class LocationWebService {
+
+    @Inject
+    private LocationService locationService;
+
+    @GET
+    @Secured
+    @Path("active")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Location> getActiveSessionLocations() {
+        return locationService.getSessionLocationsWithGeoJson();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingView.java
+++ b/src/main/java/com/clueride/domain/outing/OutingView.java
@@ -50,11 +50,13 @@ public class OutingView {
     private final String guideName;
     private final Integer guideMemberId;
     private final String teamName;
+    private final Integer courseId;
 
     public OutingView(OutingViewBuilder builder) {
         this.id = builder.getId();
         this.scheduledTime = builder.getScheduledTime();
         this.startPin = builder.getStartPin();
+        this.courseId = builder.getCourseId();
         this.courseName = builder.getCourseName();
         this.courseDescription = builder.getCourseDescription();
         this.courseUrl = builder.getCourseUrl();
@@ -73,6 +75,10 @@ public class OutingView {
 
     public LatLon getStartPin() {
         return startPin;
+    }
+
+    public Integer getCourseId() {
+        return courseId;
     }
 
     public String getCourseName() {

--- a/src/main/java/com/clueride/domain/path/Path.java
+++ b/src/main/java/com/clueride/domain/path/Path.java
@@ -19,6 +19,7 @@ package com.clueride.domain.path;
 
 import java.util.List;
 
+import com.clueride.domain.course.Course;
 import com.clueride.domain.course.Step;
 import com.clueride.domain.location.Location;
 
@@ -45,6 +46,14 @@ public interface Path extends Step {
      * @return Integer representing this Path.
      */
     Integer getId();
+
+    /**
+     * Since a given Path can be part of multiple courses, this may
+     * not always be defined. As part of a given Course however, this
+     * field will reference that {@link Course}.
+     * @return associated Course, if any and null otherwise.
+     */
+    Integer getCourseId();
 
     /**
      * ID of the Node at the start of this Path; the Departure.

--- a/src/main/java/com/clueride/domain/path/PathForCourse.java
+++ b/src/main/java/com/clueride/domain/path/PathForCourse.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/27/19.
+ */
+package com.clueride.domain.path;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * The data for a Path which links a Course to its Locations.
+ */
+@Immutable
+public class PathForCourse implements Path {
+    private final Integer id;
+    private final Integer courseId;
+    private final Integer startNodeId;
+    private final Integer startLocationId;
+    private final Integer endNodeId;
+    private final Integer endLocationId;
+
+    public PathForCourse(PathForCourseBuilder pathForCourseBuilder) {
+        this.id = pathForCourseBuilder.getId();
+        this.courseId = pathForCourseBuilder.getCourseId();
+        this.startNodeId = pathForCourseBuilder.getStartNodeId();
+        this.startLocationId = pathForCourseBuilder.getStartLocationId();
+        this.endNodeId = pathForCourseBuilder.getEndNodeId();
+        this.endLocationId = pathForCourseBuilder.getEndLocationId();
+    }
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public Integer getCourseId() {
+        return courseId;
+    }
+
+    @Override
+    public Integer getStartNodeId() {
+        return this.startNodeId;
+    }
+
+    @Override
+    public Integer getEndNodeId() {
+        return this.endNodeId;
+    }
+
+    @Override
+    public List<Integer> getEdgeIds() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Integer getStartLocationId() {
+        return this.startLocationId;
+    }
+
+    @Override
+    public Integer getEndLocationId() {
+        return this.endLocationId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/path/PathForCourseBuilder.java
+++ b/src/main/java/com/clueride/domain/path/PathForCourseBuilder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/27/19.
+ */
+package com.clueride.domain.path;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * JPA-aware reading of Path information for assembling the data
+ * without Geometry for a Course and its locations.
+ *
+ * This class is used to tie together the IDs, but not necessarily
+ * the actual entities behind those IDs. It's the responsibility of
+ * the Location and Course services to fill out those objects.
+ */
+@Entity(name="PathForCourse")
+@Table(name="course_path_location")
+public class PathForCourseBuilder {
+    @Id
+    private Integer id;
+    @Column(name="course_id")
+    private Integer courseId;
+    @Column(name="path_id")
+    private Integer pathId;
+    @Column(name="path_order")
+    private Integer pathOrder;
+    @Column(name="start_node_id")
+    private Integer startNodeId;
+    @Column(name="end_node_id")
+    private Integer endNodeId;
+    @Column(name="start_location_id")
+    private Integer startLocationId;
+    @Column(name="end_location_id")
+    private Integer endLocationId;
+
+    public PathForCourse build() {
+        return new PathForCourse(this);
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Integer getCourseId() {
+        return courseId;
+    }
+
+    public Integer getPathId() {
+        return pathId;
+    }
+
+    public Integer getPathOrder() {
+        return pathOrder;
+    }
+
+    public void setPathOrder(Integer pathOrder) {
+        this.pathOrder = pathOrder;
+    }
+
+    public Integer getStartNodeId() {
+        return startNodeId;
+    }
+
+    public Integer getEndNodeId() {
+        return endNodeId;
+    }
+
+    public Integer getStartLocationId() {
+        return startLocationId;
+    }
+
+    public Integer getEndLocationId() {
+        return endLocationId;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setCourseId(Integer courseId) {
+        this.courseId = courseId;
+    }
+
+    public void setPathId(Integer pathId) {
+        this.pathId = pathId;
+    }
+
+    public void setStartNodeId(Integer startNodeId) {
+        this.startNodeId = startNodeId;
+    }
+
+    public void setEndNodeId(Integer endNodeId) {
+        this.endNodeId = endNodeId;
+    }
+
+    public void setStartLocationId(Integer startLocationId) {
+        this.startLocationId = startLocationId;
+    }
+
+    public void setEndLocationId(Integer endLocationId) {
+        this.endLocationId = endLocationId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/path/PathForCourseStore.java
+++ b/src/main/java/com/clueride/domain/path/PathForCourseStore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/27/19.
+ */
+package com.clueride.domain.path;
+
+import java.util.List;
+
+import com.clueride.domain.course.Course;
+
+/**
+ * Defines Persistence operations for {@link PathForCourse} instances.
+ */
+public interface PathForCourseStore {
+    /**
+     * Retrieves the list of ordered Paths associated with the given Course ID.
+     * @param courseId unique identifier for the {@link Course}.
+     * @return Ordered list of the {@link PathForCourseBuilder} instances defined
+     * for the given course.
+     */
+    List<PathForCourseBuilder> getPathsForCourse(Integer courseId);
+
+}

--- a/src/main/java/com/clueride/domain/path/PathForCourseStoreJpa.java
+++ b/src/main/java/com/clueride/domain/path/PathForCourseStoreJpa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Jett Marks
+ * Copyright 2019 Jett Marks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,32 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 9/10/17.
+ * Created by jett on 1/27/19.
  */
-package com.clueride.domain.location.latlon;
+package com.clueride.domain.path;
 
-import java.io.IOException;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 /**
- * JPA implementation of the Loc LatLon Store.
+ * JPA-implementation of {@link PathForCourseStore}.
  */
-public class LatLonStoreJpa implements LatLonStore {
+public class PathForCourseStoreJpa implements PathForCourseStore {
     @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
 
     @Override
-    public Integer addNew(LatLon latLon) throws IOException {
-        entityManager.persist(latLon);
-        return latLon.getId();
-    }
+    public List<PathForCourseBuilder> getPathsForCourse(Integer courseId) {
+        List<PathForCourseBuilder> builders;
+        builders = entityManager.createQuery(
+               "SELECT p FROM PathForCourse p " +
+                       " WHERE p.courseId = :courseId" +
+                       " ORDER BY p.pathOrder"
+        ).setParameter(
+                "courseId", courseId
+        ).getResultList();
 
-    @Override
-    public LatLon getLatLonById(Integer id) {
-        LatLon latLon = entityManager.find(LatLon.class, id);
-        return latLon;
+        return builders;
     }
-
 }

--- a/src/main/java/com/clueride/network/path/PathService.java
+++ b/src/main/java/com/clueride/network/path/PathService.java
@@ -17,13 +17,19 @@
  */
 package com.clueride.network.path;
 
+import java.util.List;
+
+import com.clueride.domain.course.Course;
+import com.clueride.domain.location.Location;
+import com.clueride.domain.path.Path;
+
 /**
  * Defines operations on {@link Path} instances.
  */
 public interface PathService {
 
     /**
-     * Retrieves the GeoJSON representation of the Path identified
+     * Retrieves the GeoJSON representation of the {@link Path} identified
      * by the pathId.
      *
      * A Path is an ordered sequence of Edge instances.
@@ -32,5 +38,13 @@ public interface PathService {
      * the Geometry for an ordered array of LineString.
      */
     String getPathGeoJsonById(Integer pathId);
+
+    /**
+     * Retrieves the ordered list of {@link Location} IDs for the course identified
+     * by the courseId.
+     * @param courseId unique identifier for the {@link Course}.
+     * @return Ordered list of the Location IDs for the Course.
+     */
+    List<Integer> getLocationIds(Integer courseId);
 
 }

--- a/src/main/java/com/clueride/network/path/PathServiceImpl.java
+++ b/src/main/java/com/clueride/network/path/PathServiceImpl.java
@@ -17,8 +17,16 @@
  */
 package com.clueride.network.path;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+
+import com.clueride.domain.path.PathForCourseBuilder;
+import com.clueride.domain.path.PathForCourseStore;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -26,11 +34,39 @@ import static java.util.Objects.requireNonNull;
  */
 public class PathServiceImpl implements PathService {
     @Inject
+    private Logger LOGGER;
+
+    @Inject
     private PathStore pathStore;
+
+    @Inject
+    private PathForCourseStore pathForCourseStore;
 
     @Override
     public String getPathGeoJsonById(Integer pathId) {
         requireNonNull(pathId, "Path ID must be provided");
         return pathStore.getPathGeoJson(pathId);
     }
+
+    @Override
+    public List<Integer> getLocationIds(Integer courseId) {
+        requireNonNull(courseId, "Course ID must be provided");
+
+        List<PathForCourseBuilder> paths = pathForCourseStore.getPathsForCourse(courseId);
+        if (paths.size() == 0) {
+            LOGGER.warn("No paths found for course ID {}", courseId );
+            return Collections.emptyList();
+        }
+
+        List<Integer> locationIds = new ArrayList<>();
+        PathForCourseBuilder lastBuilder = null;
+        for (PathForCourseBuilder builder : paths) {
+            locationIds.add(builder.getStartLocationId());
+            lastBuilder = builder;
+        }
+        locationIds.add(lastBuilder.getEndLocationId());
+
+        return locationIds;
+    }
+
 }

--- a/src/main/java/com/clueride/network/path/PathStore.java
+++ b/src/main/java/com/clueride/network/path/PathStore.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.network.path;
 
+import com.clueride.domain.path.Path;
+
 /**
  * Defines persistence operations on a {@link Path} instance.
  */

--- a/src/main/java/com/clueride/network/path/PathStoreJpa.java
+++ b/src/main/java/com/clueride/network/path/PathStoreJpa.java
@@ -21,9 +21,9 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 /**
- * TODO: Description.
+ * JPA implementation of {@link PathStore} that supports GeoJSON query.
  */
-public class PathStoreImpl implements PathStore {
+public class PathStoreJpa implements PathStore {
 
     @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
@@ -46,4 +46,5 @@ public class PathStoreImpl implements PathStore {
                 .setParameter(1, pathId)
                 .getSingleResult();
     }
+
 }


### PR DESCRIPTION
- Adds WebService for populating the Location Cache within the front-end.
- Amends the existing Location object to hold LocationType and LatLon instances; not quite ready for GeoJSON, but it has the data to build this on the front-end for now.
- Adds to the CourseService to retrieve a list of the Locations. This includes making use of the Path service to retrieve a list of Paths.
- Adds method to PathService for retrieving the list of Paths for a Course; also adds the JPA Store to support this.
- There's a field for the Course in the Session DTO, but not yet being used.