### PR TITLE
SVR-8 Support for GameState REST requests

### DIFF
--- a/src/main/java/com/clueride/auth/ClueRideSessionDto.java
+++ b/src/main/java/com/clueride/auth/ClueRideSessionDto.java
@@ -87,12 +87,4 @@ public class ClueRideSessionDto implements Serializable {
         this.course = course;
     }
 
-    public GameState getGameState() {
-        return gameState;
-    }
-
-    public void setGameState(GameState gameState) {
-        this.gameState = gameState;
-    }
-
 }

--- a/src/main/java/com/clueride/domain/game/GameStateService.java
+++ b/src/main/java/com/clueride/domain/game/GameStateService.java
@@ -22,17 +22,25 @@ package com.clueride.domain.game;
  */
 public interface GameStateService {
     /**
+     * Retrieves the current game state for the session from the session.
+     * If this session is empty, ask the GameState Service to provide the instance for the outing
+     * and cache this in the session before returning to client.
+     * @return Active Session's Game State -- either cached, or now placed in cache.
+     */
+    GameState getActiveSessionGameState();
+
+    /**
      * Given a Team's ID, return the most recently stored State for that Team.
      * @param teamId - Unique Integer identifying the Team whose State to be retrieved.
      * @return - JSON String representing the entire state object.
      */
     String getGameStateByTeam(Integer teamId);
-
     /**
      * Update the stored Game State for a team using the given instance.
      * @param clueRideState - State values to be used for the update.
      * @return - JSON object indicating success of update.
      */
+
 //    String updateGameStateByTeam(ClueRideState clueRideState);
 
     /**

--- a/src/main/java/com/clueride/domain/game/GameStateWebService.java
+++ b/src/main/java/com/clueride/domain/game/GameStateWebService.java
@@ -19,6 +19,7 @@ package com.clueride.domain.game;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -34,6 +35,13 @@ public class GameStateWebService {
 
     @Inject
     private GameStateService gameStateService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public GameState getActiveSessionGameState() {
+        return gameStateService.getActiveSessionGameState();
+    }
 
     @POST
     @Secured

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.domain.game.ssevent;
 
+import com.clueride.domain.game.GameState;
+
 /**
  * Handles the generation and propagation of Events from the Game's point of view.
  *
@@ -29,12 +31,13 @@ public interface SSEventService {
      * we're beginning the game.
      *
      * @param outingId Unique identifier for the Outing that is beginning play; indicates which channel is updated.
+     * @param gameState Updated GameState for sharing with clients.
      * @return ID of the message.
      */
-    Integer sendTeamReadyEvent(Integer outingId);
+    Integer sendTeamReadyEvent(Integer outingId, GameState gameState);
 
-    Integer sendArrivalEvent(Integer outingId);
+    Integer sendArrivalEvent(Integer outingId, GameState gameState);
 
-    Integer sendDepartureEvent(Integer outingId);
+    Integer sendDepartureEvent(Integer outingId, GameState gameState);
 
 }

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
@@ -45,7 +45,6 @@ import com.clueride.domain.game.GameState;
  */
 public class SSEventServiceImpl implements SSEventService {
     private final Logger LOGGER;
-    private final ConfigService configService;
     private final String sseHost;
 
     @Inject
@@ -65,34 +64,33 @@ public class SSEventServiceImpl implements SSEventService {
             ConfigService configService,
             Logger logger
     ) {
-        this.configService = configService;
-        this.sseHost = this.configService.get("sse.host");
+        this.sseHost = configService.get("sse.host");
         this.LOGGER = logger;
         LOGGER.debug("Communicating with SSE server at " + sseHost);
     }
 
     @Override
-    public Integer sendTeamReadyEvent(Integer outingId) {
-        return sendEvent(eventMessageFromString("Team Assembled"));
+    public Integer sendTeamReadyEvent(Integer outingId, GameState gameState) {
+        return sendEvent(eventMessageFromString("Team Assembled", gameState));
     }
 
     @Override
-    public Integer sendArrivalEvent(Integer outingId) {
-        return sendEvent(eventMessageFromString("Arrival"));
+    public Integer sendArrivalEvent(Integer outingId, GameState gameState) {
+        return sendEvent(eventMessageFromString("Arrival", gameState));
     }
 
     @Override
-    public Integer sendDepartureEvent(Integer outingId) {
-        return sendEvent(eventMessageFromString("Departure"));
+    public Integer sendDepartureEvent(Integer outingId, GameState gameState) {
+        return sendEvent(eventMessageFromString("Departure", gameState));
     }
 
     /** Builds the Event from Session information including the Game State. */
-    private String eventMessageFromString(String event) {
+    private String eventMessageFromString(String event, GameState gameState) {
         SSEventMessage ssEventMessage =
                 new SSEventMessage(
                         event,
                         clueRideSessionDto.getOutingView().getId(),
-                        clueRideSessionDto.getGameState()
+                        gameState
                 );
         try {
             return objectMapper.writeValueAsString(
@@ -114,7 +112,7 @@ public class SSEventServiceImpl implements SSEventService {
     private Integer sendEvent(
             String message
     ) {
-        Integer responseCode = 500;
+        int responseCode = 500;
         try {
             URL url = urlForSession();
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -167,7 +165,7 @@ public class SSEventServiceImpl implements SSEventService {
         Integer outingId;
         GameState gameState;
 
-        public SSEventMessage(String event, Integer id, GameState gameState) {
+        SSEventMessage(String event, Integer id, GameState gameState) {
             this.event = event;
             this.outingId = id;
             this.gameState = gameState;


### PR DESCRIPTION
- Adds endpoint for requesting the GameState.
- Pulls GameState out of the Session -- it's not an object that follows the session life-cycle. This implies that I need to pass the event to the SSE service since it was being passed in the session.