### PR TITLE
SVR-15 API Support for adding a new Puzzle

### DIFF
--- a/src/main/java/com/clueride/domain/image/ImageEntity.java
+++ b/src/main/java/com/clueride/domain/image/ImageEntity.java
@@ -41,6 +41,14 @@ public class ImageEntity {
     @Column
     private String url;
 
+    /** Empty constructor for JPA. */
+    public ImageEntity() {}
+
+    /** String constructor for REST API. */
+    public ImageEntity(String featuredImage) {
+        this.url = featuredImage;
+    }
+
     public Integer getId() {
         return id;
     }

--- a/src/main/java/com/clueride/domain/image/ImageServiceImpl.java
+++ b/src/main/java/com/clueride/domain/image/ImageServiceImpl.java
@@ -82,11 +82,12 @@ public class ImageServiceImpl implements ImageService {
 
     private ImageEntity persistImageMetadata(Integer locationId, Integer imageOnFileSystemId) {
         /* Build and assign URL. */
-        ImageEntity imageEntity = new ImageEntity();
-        imageEntity.setUrl(buildImageUrlString(
-                locationId,
-                imageOnFileSystemId
-        ));
+        ImageEntity imageEntity = new ImageEntity(
+                buildImageUrlString(
+                        locationId,
+                        imageOnFileSystemId
+                )
+        );
 
         imageStore.addNewToLocation(imageEntity, locationId);
         return imageEntity;

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleBuilder.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleBuilder.java
@@ -32,6 +32,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -70,6 +71,12 @@ public final class PuzzleBuilder {
     @JoinColumn(name = "location_id")
     private LocationBuilder locationBuilder;
 
+    /* Supports REST API. */
+    @Transient
+    private Integer locationId;
+    @Transient
+    private String locationName;
+
     public static PuzzleBuilder builder() {
         return new PuzzleBuilder();
     }
@@ -83,6 +90,20 @@ public final class PuzzleBuilder {
                 .withAnswers(instance.getAnswers())
                 .withPoints(instance.getPoints())
                 ;
+    }
+
+    public Integer getLocationId() {
+        return locationId;
+    }
+
+    /* Supports REST API. */
+    public void setLocationId(Integer locationId) {
+        this.locationId = locationId;
+    }
+
+    /* Supports REST API. */
+    public void setLocationName(String locationName) {
+        this.locationName = locationName;
     }
 
     public String getQuestion() {

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
@@ -42,9 +42,14 @@ public interface PuzzleService {
     /**
      * Create a New puzzle instance for the given Location.
      * @param puzzleBuilder data for the new Puzzle.
-     * @param locationBuilder data for the Location to accept the new Puzzle.
      * @return fully-populated instance of the new Puzzle.
      */
-    Puzzle addNew(PuzzleBuilder puzzleBuilder, LocationBuilder locationBuilder);
+    Puzzle addNew(PuzzleBuilder puzzleBuilder);
+
+    /**
+     * Creates a New puzzle instance for the front-end to populate.
+     * @return Empty Puzzle ready to be filled by the client.
+     */
+    Puzzle getBlankPuzzleForLocation(LocationBuilder locationBuilder);
 
 }

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
@@ -19,8 +19,15 @@ package com.clueride.domain.puzzle;
 
 import java.util.List;
 
+import javax.annotation.Resource;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
 
 import com.clueride.domain.location.LocationBuilder;
 
@@ -32,20 +39,25 @@ public class PuzzleStoreJpa implements PuzzleStore {
     @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
 
+    @Resource
+    private UserTransaction userTransaction;
+
     @Override
     public Integer addNew(PuzzleBuilder puzzleBuilder) {
-        entityManager.getTransaction().begin();
-        entityManager.persist(puzzleBuilder);
-        entityManager.getTransaction().commit();
+        try {
+            userTransaction.begin();
+            entityManager.persist(puzzleBuilder);
+            userTransaction.commit();
+        } catch (NotSupportedException | RollbackException | HeuristicMixedException | HeuristicRollbackException | SystemException e) {
+            e.printStackTrace();
+        }
         return puzzleBuilder.getId();
     }
 
     @Override
     public PuzzleBuilder getPuzzleById(Integer id) {
         PuzzleBuilder puzzleBuilder;
-        entityManager.getTransaction().begin();
         puzzleBuilder = entityManager.find(PuzzleBuilder.class, id);
-        entityManager.getTransaction().commit();
         return puzzleBuilder;
     }
 

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleWebService.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleWebService.java
@@ -20,13 +20,16 @@ package com.clueride.domain.puzzle;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.clueride.auth.Secured;
+import com.clueride.domain.location.LocationBuilder;
 import com.clueride.domain.puzzle.answer.Answer;
 
 /**
@@ -46,4 +49,20 @@ public class PuzzleWebService {
         return puzzleService.getByLocation(locationId);
     }
 
+    @POST
+    @Secured
+    @Path("blank")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Puzzle getBlankPuzzle(LocationBuilder locationBuilder) {
+        return puzzleService.getBlankPuzzleForLocation(locationBuilder);
+    }
+
+    @POST
+    @Secured
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Puzzle savePuzzle(PuzzleBuilder puzzleBuilder) {
+        return puzzleService.addNew(puzzleBuilder);
+    }
 }


### PR DESCRIPTION
- Accepts request for a blank Puzzle to be filled out (wanted to
initialize this server-side.
- Accepts PuzzleBuilder which has been filled out for persisting.
- Adjusts ImageEntity to allow construction for JPA and REST (including
a constructor that accepts the URL as a string).
- Adjusts PuzzleBuilder to allow construction by the REST API.