### PR TITLE
SVR-21 Support for posting an Answer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <version.war.plugin>2.5</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <licenses>

--- a/src/main/java/com/clueride/aop/badge/BadgeCaptureInterceptor.java
+++ b/src/main/java/com/clueride/aop/badge/BadgeCaptureInterceptor.java
@@ -27,8 +27,8 @@ import javax.interceptor.InvocationContext;
 
 import org.slf4j.Logger;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.badge.event.BadgeEventBuilder;
 import com.clueride.domain.badge.event.BadgeEventService;
 

--- a/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/clueride/auth/filter/AuthenticationFilter.java
@@ -35,10 +35,10 @@ import javax.ws.rs.ext.Provider;
 import org.slf4j.Logger;
 
 import com.clueride.RecordNotFoundException;
-import com.clueride.auth.ClueRideSession;
 import com.clueride.auth.Secured;
 import com.clueride.auth.access.AccessTokenService;
 import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.auth.session.ClueRideSession;
 import com.clueride.config.ConfigService;
 import com.clueride.domain.account.principal.PrincipalService;
 

--- a/src/main/java/com/clueride/auth/session/ClueRideSession.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSession.java
@@ -15,7 +15,7 @@
  *
  * Created by jett on 12/1/18.
  */
-package com.clueride.auth;
+package com.clueride.auth.session;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
@@ -15,7 +15,7 @@
  *
  * Created by jett on 12/2/18.
  */
-package com.clueride.auth;
+package com.clueride.auth.session;
 
 import java.io.Serializable;
 
@@ -23,9 +23,9 @@ import com.clueride.auth.identity.ClueRideIdentity;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.course.Course;
-import com.clueride.domain.game.GameState;
 import com.clueride.domain.invite.Invite;
 import com.clueride.domain.outing.OutingView;
+import com.clueride.domain.puzzle.state.PuzzleState;
 
 /**
  * "Holder" for session-related class instances.
@@ -37,7 +37,7 @@ public class ClueRideSessionDto implements Serializable {
     private Invite invite = null;
     private OutingView outingView = null;
     private Course course = null;
-    private GameState gameState = null;
+    private PuzzleState puzzleState = null;
 
     public void setClueRideIdentity(ClueRideIdentity clueRideIdentity) {
         this.clueRideIdentity = clueRideIdentity;
@@ -85,6 +85,14 @@ public class ClueRideSessionDto implements Serializable {
 
     public void setCourse(Course course) {
         this.course = course;
+    }
+
+    public void setPuzzleState(PuzzleState puzzleState) {
+        this.puzzleState = puzzleState;
+    }
+
+    public PuzzleState getPuzzleState() {
+        return puzzleState;
     }
 
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionService.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/28/19.
+ */
+package com.clueride.auth.session;
+
+/**
+ * Defines operations on Clue Ride Sessions held in cache.
+ */
+public interface ClueRideSessionService {
+    /**
+     * Given an properly formatted token, retrieve the mapped Session object.
+     *
+     * @param token unique and opaque token representing the user's session.
+     * @return Matching Session DTO holding the session state.
+     */
+    ClueRideSessionDto getSessionFromToken(String token);
+
+    /**
+     * Maintains the session information for a given token.
+     * @param token unique and opaque token representing the user's session.
+     * @param sessionDto Session DTO holding the session state.
+     */
+    void setSessionForToken(String token, ClueRideSessionDto sessionDto);
+
+}

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/28/19.
+ */
+package com.clueride.auth.session;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implementation of {@link ClueRideSessionService} backed by a simple Map.
+ *
+ * TODO: This needs to be reconstructed so it's members can be expired.
+ */
+public class ClueRideSessionServiceImpl implements ClueRideSessionService {
+    private static Map<String, ClueRideSessionDto> sessionMap = new HashMap<>();
+
+    @Override
+    public ClueRideSessionDto getSessionFromToken(String token) {
+        return sessionMap.get(token);
+    }
+
+    @Override
+    public void setSessionForToken(String token, ClueRideSessionDto sessionDto) {
+        sessionMap.put(token, sessionDto);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
@@ -30,9 +30,9 @@ import org.slf4j.Logger;
 
 import com.clueride.RecordNotFoundException;
 import com.clueride.aop.badge.BadgeCapture;
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
 import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 
 /**
  * Implementation of {@link MemberService}.

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
@@ -26,11 +26,10 @@ import javax.inject.Inject;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
-
 import org.slf4j.Logger;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/src/main/java/com/clueride/domain/badge/BadgeServiceImpl.java
+++ b/src/main/java/com/clueride/domain/badge/BadgeServiceImpl.java
@@ -25,8 +25,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
 
 /**

--- a/src/main/java/com/clueride/domain/course/Course.java
+++ b/src/main/java/com/clueride/domain/course/Course.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.util.List;
 
 import com.clueride.domain.location.Location;
-import com.clueride.domain.path.Path;
 
 /**
  * Representation of a Course, including an ordered list of Locations and the Paths
@@ -33,7 +32,7 @@ public interface Course {
     String getDescription();
     URL getUrl();
     Integer getCourseTypeId();
-    List<Step> getSteps();
+    List<Integer> getLocationIdList();
     List<Integer> getPathIds();
     Location getDeparture();
     Location getDestination();
@@ -42,12 +41,4 @@ public interface Course {
 //    Step nextStep();
 //    Step currentStep();
 
-    /**
-     * As progress is made along the course, each step is completed by calling
-     * this method.
-     * For example, upon departure from the first {@link Location}, that step is completed
-     * and the state changes to the first {@link Path}.
-     * @return The last current step which we've marked as completed (giving us a new current Step).
-     */
-//    Step completeCurrentStep();
 }

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -20,7 +20,6 @@ package com.clueride.domain.course;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -54,6 +53,19 @@ public class CourseServiceImpl implements CourseService {
     @Override
     public Course getById(final Integer courseId) {
         /* Interim implementation. */
+        // TODO: sort out whether the Path Service should be providing this.
+        final List<Integer> interimPathIds = Arrays.asList(
+                6,
+                4,
+                3,
+                13,
+                9,
+                10,
+                2
+        );
+
+        final List<Integer> interimLocations = pathService.getLocationIds(courseId);
+
         return new Course(){
 
             @Override
@@ -77,21 +89,13 @@ public class CourseServiceImpl implements CourseService {
             }
 
             @Override
-            public List<Step> getSteps() {
-                return Collections.EMPTY_LIST;
+            public List<Integer> getLocationIdList() {
+                return interimLocations;
             }
 
             @Override
             public List<Integer> getPathIds() {
-                return Arrays.asList(
-                        6,
-                        4,
-                        3,
-                        13,
-                        9,
-                        10,
-                        2
-                );
+                return interimPathIds;
             }
 
             @Override

--- a/src/main/java/com/clueride/domain/course/GameCourse.java
+++ b/src/main/java/com/clueride/domain/course/GameCourse.java
@@ -41,7 +41,6 @@ public class GameCourse implements Course {
     private final String name;
     private final String description;
     private final Integer courseTypeId;
-    private final List<Step> steps;
     private final List<Integer> pathIds;
     private final Location departure;
     private final Location destination;
@@ -51,7 +50,6 @@ public class GameCourse implements Course {
         this.name = builder.getName();
         this.description = builder.getDescription();
         this.courseTypeId = builder.getCourseTypeId();
-        this.steps = builder.getSteps();
         this.pathIds = builder.getPathIds();
         this.departure = builder.getDeparture();
         this.destination = builder.getDestination();
@@ -83,7 +81,7 @@ public class GameCourse implements Course {
     }
 
     @Override
-    public List<Step> getSteps() {
+    public List<Integer> getLocationIdList() {
         return null;
     }
 
@@ -117,7 +115,7 @@ public class GameCourse implements Course {
         private String name;
         private String description;
         private Integer courseTypeId;
-        private List<Step> steps;
+        private List<Integer> locationIds;
         private List<Integer> pathIds;
         private Location departure;
         private Location destination;
@@ -132,7 +130,7 @@ public class GameCourse implements Course {
                     .withName(course.getName())
                     .withDescription(course.getDescription())
                     .withCourseTypeId(course.getCourseTypeId())
-                    .withSteps(course.getSteps())
+                    .withLocationIdList(course.getLocationIdList())
                     ;
         }
 
@@ -176,12 +174,12 @@ public class GameCourse implements Course {
             return this;
         }
 
-        public List<Step> getSteps() {
-            return steps;
+        public List<Integer> getSteps() {
+            return locationIds;
         }
 
-        public Builder withSteps(List<Step> steps) {
-            this.steps = steps;
+        public Builder withLocationIdList(List<Integer> locationIdList) {
+            this.locationIds = locationIdList;
             return this;
         }
 

--- a/src/main/java/com/clueride/domain/game/GameState.java
+++ b/src/main/java/com/clueride/domain/game/GameState.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import com.clueride.domain.course.Course;
+
 /**
  * Defines what we need to track the state of the Game for the clients.
  */
@@ -30,14 +32,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class GameState {
     private final Boolean teamAssembled;
     private final Boolean rolling;
-    private final String nextLocation;
+    private final String nextLocationName;
     private final Integer pathIndex;
+    private final Integer locationId;
+    private final Integer puzzleId;
 
     private GameState(Builder builder) {
         this.teamAssembled = builder.getTeamAssembled();
         this.rolling = builder.getRolling();
-        this.nextLocation = builder.getNextLocation();
+        this.nextLocationName = builder.getNextLocation();
         this.pathIndex = builder.getPathIndex();
+        this.locationId = builder.getLocationId();
+        this.puzzleId = builder.getPuzzleId();
     }
 
     public Boolean getTeamAssembled() {
@@ -48,12 +54,20 @@ public class GameState {
         return rolling;
     }
 
-    public String getNextLocation() {
-        return nextLocation;
+    public String getNextLocationName() {
+        return nextLocationName;
     }
 
     public Integer getPathIndex() {
         return pathIndex;
+    }
+
+    public Integer getLocationId() {
+        return locationId;
+    }
+
+    public Integer getPuzzleId() {
+        return puzzleId;
     }
 
     @Override
@@ -72,11 +86,13 @@ public class GameState {
     }
 
     public static class Builder {
-        /* Initial Game State */
+        /* Initial Game State -- without knowing the Course. */
         private Boolean teamAssembled = false;
         private Boolean rolling = false;
-        private String nextLocation = "Meeting Location";
+        private String nextLocationName = "Meeting Location";
         private Integer pathIndex = -1;
+        private Integer locationId = null;
+        private Integer puzzleId = null;
 
         public GameState build() {
             return new GameState(this);
@@ -90,8 +106,10 @@ public class GameState {
             return builder()
                     .withTeamAssembled(gameState.getTeamAssembled())
                     .withRolling(gameState.getRolling())
-                    .withNextLocation(gameState.getNextLocation())
-                    .withPathIndex(gameState.getPathIndex());
+                    .withNextLocationName(gameState.getNextLocationName())
+                    .withPathIndex(gameState.getPathIndex())
+                    .withLocationId(gameState.getLocationId())
+                    .withPuzzleId(gameState.getPuzzleId());
         }
 
         public Boolean getTeamAssembled() {
@@ -113,11 +131,11 @@ public class GameState {
         }
 
         public String getNextLocation() {
-            return nextLocation;
+            return nextLocationName;
         }
 
-        public Builder withNextLocation(String nextLocation) {
-            this.nextLocation = nextLocation;
+        public Builder withNextLocationName(String nextLocationName) {
+            this.nextLocationName = nextLocationName;
             return this;
         }
 
@@ -129,6 +147,36 @@ public class GameState {
             this.pathIndex = pathIndex;
             return this;
         }
+
+        public Builder incrementPathIndex(int moduloValue) {
+            /* TODO: this is an interim definition for ease of testing; we'll want to avoid going past the end. */
+            /* TODO: SVR-9 - Set Completed flag if this was the last location. */
+            return withPathIndex((pathIndex + 1) % moduloValue);
+        }
+
+        public Integer getLocationId() {
+            return locationId;
+        }
+
+        public Builder withLocationId(Integer locationId) {
+            this.locationId = locationId;
+            return this;
+        }
+
+        public Integer getPuzzleId() {
+            return puzzleId;
+        }
+
+        public Builder withPuzzleId(Integer puzzleId) {
+            this.puzzleId = puzzleId;
+            return this;
+        }
+
+        public Builder bumpLocation(Course course) {
+            this.locationId = course.getPathIds().get(pathIndex + 1);
+            return this;
+        }
+
     }
 
 }

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventService.java
@@ -18,6 +18,7 @@
 package com.clueride.domain.game.ssevent;
 
 import com.clueride.domain.game.GameState;
+import com.clueride.domain.puzzle.answer.AnswerSummary;
 
 /**
  * Handles the generation and propagation of Events from the Game's point of view.
@@ -39,5 +40,7 @@ public interface SSEventService {
     Integer sendArrivalEvent(Integer outingId, GameState gameState);
 
     Integer sendDepartureEvent(Integer outingId, GameState gameState);
+
+    Integer sendAnswerSummaryEvent(Integer outingId, AnswerSummary answerSummary);
 
 }

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
@@ -32,10 +32,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.config.ConfigService;
 import com.clueride.domain.game.GameState;
+import com.clueride.domain.puzzle.answer.AnswerSummary;
 
 
 /**
@@ -82,6 +83,12 @@ public class SSEventServiceImpl implements SSEventService {
     @Override
     public Integer sendDepartureEvent(Integer outingId, GameState gameState) {
         return sendEvent(eventMessageFromString("Departure", gameState));
+    }
+
+    @Override
+    public Integer sendAnswerSummaryEvent(Integer outingId, AnswerSummary answerSummary) {
+        // TODO: Implement this
+        return null;
     }
 
     /** Builds the Event from Session information including the Game State. */

--- a/src/main/java/com/clueride/domain/invite/InviteServiceImpl.java
+++ b/src/main/java/com/clueride/domain/invite/InviteServiceImpl.java
@@ -24,8 +24,8 @@ import java.util.List;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.member.MemberService;
 import com.clueride.domain.course.Course;

--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import com.clueride.domain.course.Step;
 import com.clueride.domain.image.ImageEntity;
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.loctype.LocationType;
@@ -42,7 +41,7 @@ import com.clueride.domain.puzzle.PuzzleBuilder;
  * @author jett
  */
 @Immutable
-public class Location implements Step {
+public class Location {
     private final Integer id;
     private final String name;
     private final String description;

--- a/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
@@ -27,8 +27,8 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 
 import com.clueride.aop.badge.BadgeCapture;
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.course.CourseService;
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.latlon.LatLonService;

--- a/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
+++ b/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 
-import com.clueride.auth.ClueRideSession;
-import com.clueride.auth.ClueRideSessionDto;
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
 
 /**
  * Implementation of OutingService.

--- a/src/main/java/com/clueride/domain/path/Path.java
+++ b/src/main/java/com/clueride/domain/path/Path.java
@@ -20,7 +20,6 @@ package com.clueride.domain.path;
 import java.util.List;
 
 import com.clueride.domain.course.Course;
-import com.clueride.domain.course.Step;
 import com.clueride.domain.location.Location;
 
 /**
@@ -36,9 +35,7 @@ import com.clueride.domain.location.Location;
  *
  * @author jett
  */
-public interface Path extends Step {
-    // TODO: Unsure who is using this, but commented out to avoid bringing this code in right now.
-//    SortedSet<Segment> getSegments();
+public interface Path {
 
     /**
      * Uniquely identifies this particular sequence of segments/edges between

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleService.java
@@ -20,6 +20,8 @@ package com.clueride.domain.puzzle;
 import java.util.List;
 
 import com.clueride.domain.location.LocationBuilder;
+import com.clueride.domain.puzzle.answer.AnswerPost;
+import com.clueride.domain.puzzle.answer.AnswerSummary;
 
 /**
  * Defines the operations on a Puzzle.
@@ -51,5 +53,13 @@ public interface PuzzleService {
      * @return Empty Puzzle ready to be filled by the client.
      */
     Puzzle getBlankPuzzleForLocation(LocationBuilder locationBuilder);
+
+    /**
+     * Posts the given answer against the current session, updates the
+     * overall Outing's summary for this puzzle, and returns that summary.
+     * @param answerPost Puzzle ID and Answer choice for that puzzle.
+     * @return Summary of responses for the puzzle references in the Answer Post.
+     */
+    AnswerSummary postAnswer(AnswerPost answerPost);
 
 }

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleWebService.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleWebService.java
@@ -28,9 +28,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.clueride.aop.badge.BadgeCapture;
 import com.clueride.auth.Secured;
 import com.clueride.domain.location.LocationBuilder;
 import com.clueride.domain.puzzle.answer.Answer;
+import com.clueride.domain.puzzle.answer.AnswerPost;
+import com.clueride.domain.puzzle.answer.AnswerSummary;
 
 /**
  * REST API for {@link Puzzle} instances and their {@link Answer} instances.
@@ -64,6 +67,16 @@ public class PuzzleWebService {
     @Produces(MediaType.APPLICATION_JSON)
     public Puzzle savePuzzle(PuzzleBuilder puzzleBuilder) {
         return puzzleService.addNew(puzzleBuilder);
+    }
+
+    @POST
+    @Secured
+    @BadgeCapture
+    @Path("answer")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public AnswerSummary postAnswerForSession(AnswerPost answerPost) {
+        return puzzleService.postAnswer(answerPost);
     }
 
 }

--- a/src/main/java/com/clueride/domain/puzzle/answer/AnswerPost.java
+++ b/src/main/java/com/clueride/domain/puzzle/answer/AnswerPost.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/26/19.
+ */
+package com.clueride.domain.puzzle.answer;
+
+/**
+ * Represents a player's choice of answer for a given puzzle.
+ */
+public class AnswerPost {
+    private Integer id;
+    private String answer;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/clueride/domain/puzzle/answer/AnswerSummary.java
+++ b/src/main/java/com/clueride/domain/puzzle/answer/AnswerSummary.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/26/19.
+ */
+package com.clueride.domain.puzzle.answer;
+
+import java.util.Map;
+
+/**
+ * Summary of the answers given during a certain outing for the given puzzle.
+ */
+public class AnswerSummary {
+    private Integer puzzleId;
+    private AnswerKey correctAnswer;
+    private AnswerKey myAnswer;
+    private Map<AnswerKey,Integer> answerMap;
+
+    public Integer getPuzzleId() {
+        return puzzleId;
+    }
+
+    public void setPuzzleId(Integer puzzleId) {
+        this.puzzleId = puzzleId;
+    }
+
+    public AnswerKey getCorrectAnswer() {
+        return correctAnswer;
+    }
+
+    public void setCorrectAnswer(AnswerKey correctAnswer) {
+        this.correctAnswer = correctAnswer;
+    }
+
+    public AnswerKey getMyAnswer() {
+        return myAnswer;
+    }
+
+    public void setMyAnswer(AnswerKey myAnswer) {
+        this.myAnswer = myAnswer;
+    }
+
+    public Map<AnswerKey, Integer> getAnswerMap() {
+        return answerMap;
+    }
+
+    public void setAnswerMap(Map<AnswerKey, Integer> answerMap) {
+        this.answerMap = answerMap;
+    }
+}

--- a/src/main/java/com/clueride/domain/puzzle/state/PuzzleState.java
+++ b/src/main/java/com/clueride/domain/puzzle/state/PuzzleState.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 2/28/19.
+ */
+package com.clueride.domain.puzzle.state;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.clueride.domain.puzzle.Puzzle;
+import com.clueride.domain.puzzle.answer.Answer;
+import com.clueride.domain.puzzle.answer.AnswerKey;
+
+/**
+ * Tracks the progress on the team's answers for a given Puzzle.
+ */
+public class PuzzleState {
+    private Puzzle puzzle;
+    private Map<AnswerKey, Integer> answerMap = new HashMap<>();
+
+    public PuzzleState (Puzzle puzzle) {
+        this.puzzle = puzzle;
+        for (Answer answer : puzzle.getAnswers()) {
+            answerMap.put(answer.getKey(), 0);
+        }
+    }
+
+    public Map<AnswerKey, Integer> postAnswer(AnswerKey answerKey) {
+        answerMap.merge(answerKey, 1, Integer::sum);
+        return answerMap;
+    }
+
+    public AnswerKey getCorrectAnswer() {
+        return this.puzzle.getCorrectAnswer();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/puzzle/state/PuzzleStateService.java
+++ b/src/main/java/com/clueride/domain/puzzle/state/PuzzleStateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Jett Marks
+ * Copyright 2019 Jett Marks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 1/15/16.
+ * Created by jett on 2/28/19.
  */
-package com.clueride.domain.course;
+package com.clueride.domain.puzzle.state;
 
 /**
- * "Marker" interface for Locations and Paths which helps keep order.
- *
- * The next Step at a Location will be a {@link Path} (or choice of Paths).  The next Step while
- * on a Path will be arrival at the next Location.
- *
- * This allows an ordered list of Steps without necessarily worrying about whether the next
- * one comes from the Location List or the Path List, or whatever else we might want to
- * stick in a {@link Course}.
+ * Defines operations on a Puzzle's State, particularly the answers.
  */
-public interface Step {
+public interface PuzzleStateService {
+
+
 
 }


### PR DESCRIPTION
- Adds AnswerPost object containing puzzle reference and answer.
- Adds AnswerSummary which pulls together a summary of answers for a puzzle on an outing.
- Adds API for posting the answer and returning the summary along with
updates to the session objects.

Not yet broadcasting the Summary -- awaiting work to turn this into a
trunk that pushes all events.

Refactors:
- Pieces of the Session
- Step is no longer needed (just use location and puzzle)

Significant:
- Working around a weak spot in creating Session objects -- now placing these in
a map keyed by the access token. (need to be careful using test tokens)
- Moves us to Java 8 to take advantage of `Map.merge()`.