### PR TITLE
SVR-34 Refactor ImageEntity to make it easier on the front-end

### DIFF
--- a/src/main/java/com/clueride/domain/image/ImageByLocation.java
+++ b/src/main/java/com/clueride/domain/image/ImageByLocation.java
@@ -28,7 +28,7 @@ import com.clueride.domain.location.Location;
 
 /**
  * Entity representing the relationship between a {@link Location} instance and
- * its set of {@link ImageEntity}.
+ * its set of {@link ImageLinkEntity}.
  */
 @Entity(name="image_by_location")
 public class ImageByLocation {

--- a/src/main/java/com/clueride/domain/image/ImageLink.java
+++ b/src/main/java/com/clueride/domain/image/ImageLink.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 4/3/19.
+ */
+package com.clueride.domain.image;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Holds the URL link for a particular Image stored on the file system.
+ */
+@Immutable
+public class ImageLink {
+    private final Integer id;
+    private final String url;
+
+    /**
+     * Default constructor
+     * @param imageLinkEntity mutable instance that is persisted to the database.
+     */
+    public ImageLink(ImageLinkEntity imageLinkEntity) {
+        this.id = imageLinkEntity.getId();
+        this.url = imageLinkEntity.getUrl();
+    }
+
+    /**
+     * Obtain a Builder instance for this class.
+     * @return empty Builder for an {@link ImageLink}.
+     */
+    public static ImageLinkEntity builder() {
+        return new ImageLinkEntity();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/image/ImageLinkEntity.java
+++ b/src/main/java/com/clueride/domain/image/ImageLinkEntity.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * This maps a file's URL with a unique ID via database table.
  */
 @Entity(name = "Image")
-public class ImageEntity {
+public class ImageLinkEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "image_pk_sequence")
     @SequenceGenerator(name = "image_pk_sequence", sequenceName = "image_id_seq", allocationSize = 1)
@@ -42,10 +42,20 @@ public class ImageEntity {
     private String url;
 
     /** Empty constructor for JPA. */
-    public ImageEntity() {}
+    public ImageLinkEntity() {}
+
+    public ImageLink build() {
+        return new ImageLink(this);
+    }
+
+    public static ImageLinkEntity from(ImageLink imageLink) {
+        return ImageLink.builder()
+                .withId(imageLink.getId())
+                .withUrl(imageLink.getUrl());
+    }
 
     /** String constructor for REST API. */
-    public ImageEntity(String featuredImage) {
+    public ImageLinkEntity(String featuredImage) {
         this.url = featuredImage;
     }
 
@@ -53,8 +63,18 @@ public class ImageEntity {
         return id;
     }
 
+    public ImageLinkEntity withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
     public String getUrl() {
         return url;
+    }
+
+    public ImageLinkEntity withUrl(String url) {
+        this.url = url;
+        return this;
     }
 
     public void setUrl(String url) {
@@ -65,4 +85,5 @@ public class ImageEntity {
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
     }
+
 }

--- a/src/main/java/com/clueride/domain/image/ImageService.java
+++ b/src/main/java/com/clueride/domain/image/ImageService.java
@@ -22,16 +22,16 @@ import java.util.List;
 import com.clueride.domain.location.Location;
 
 /**
- * Defines operations on {@link ImageEntity} instances.
+ * Defines operations on {@link ImageLinkEntity} instances.
  */
 public interface ImageService {
 
     /**
      * For the given Location ID, return all the associated images.
      * @param locationId unique identifier for the Location.
-     * @return List of {@link ImageEntity} matching the given location.
+     * @return List of {@link ImageLinkEntity} matching the given location.
      */
-    List<ImageEntity> getImagesForLocation(Integer locationId);
+    List<ImageLinkEntity> getImagesForLocation(Integer locationId);
 
     /**
      * Uploads and persists a new Image.
@@ -41,6 +41,6 @@ public interface ImageService {
      *                           InputStream of the image.
      * @return Identifying record for this image, including its URL on the system.
      */
-    ImageEntity saveLocationImage(ImageUploadRequest imageUploadRequest);
+    ImageLinkEntity saveLocationImage(ImageUploadRequest imageUploadRequest);
 
 }

--- a/src/main/java/com/clueride/domain/image/ImageStore.java
+++ b/src/main/java/com/clueride/domain/image/ImageStore.java
@@ -23,7 +23,7 @@ import java.util.List;
 import com.clueride.domain.location.Location;
 
 /**
- * Defines JPA and File System operations on {@link ImageEntity} instances.
+ * Defines JPA and File System operations on {@link ImageLinkEntity} instances.
  *
  * In the case of Image data, we would expect to write the data out to
  * the web server's Document directory where URLs can be used to retrieve
@@ -34,11 +34,11 @@ import com.clueride.domain.location.Location;
  */
 public interface ImageStore {
     /**
-     * Retrieves the list of {@link ImageEntity} instances for the given location.
+     * Retrieves the list of {@link ImageLinkEntity} instances for the given location.
      * @param locationId unique identifier for the location.
-     * @return List of matching {@link ImageEntity}.
+     * @return List of matching {@link ImageLinkEntity}.
      */
-    List<ImageEntity> getImagesForLocation(Integer locationId);
+    List<ImageLinkEntity> getImagesForLocation(Integer locationId);
 
     /**
      * Accepts InputStream of image data to persist along with
@@ -55,13 +55,13 @@ public interface ImageStore {
     Integer addNew(Integer locationId, InputStream convertedFileData);
 
     /**
-     * Accepts the ImageEntity which contains the URL of an image which
+     * Accepts the ImageLinkEntity which contains the URL of an image which
      * has been placed on the Image Web Server's file system along with
      * the Location ID of the Location to association with the image, and
      * persists this link in the JPA-based database.
-     * @param imageEntity Image's URL record.
+     * @param imageLinkEntity Image's URL record.
      * @param locationId Unique identifier for the {@link Location} instance.
      * @return unique identifier for the link record.
      */
-    Integer addNewToLocation(ImageEntity imageEntity, Integer locationId);
+    Integer addNewToLocation(ImageLinkEntity imageLinkEntity, Integer locationId);
 }

--- a/src/main/java/com/clueride/domain/image/ImageStoreImpl.java
+++ b/src/main/java/com/clueride/domain/image/ImageStoreImpl.java
@@ -58,13 +58,13 @@ public class ImageStoreImpl implements ImageStore {
     private ConfigService config;
 
     @Override
-    public List<ImageEntity> getImagesForLocation(Integer locationId) {
-        List<ImageEntity> images = entityManager
+    public List<ImageLinkEntity> getImagesForLocation(Integer locationId) {
+        List<ImageLinkEntity> images = entityManager
                 .createQuery(
                         "select i from Image i, image_by_location l" +
                                 " where i.id = l.imageId" +
                                 "   and l.locationId = :locationId",
-                        ImageEntity.class
+                        ImageLinkEntity.class
                 )
                 .setParameter("locationId", locationId)
                 .getResultList();
@@ -129,19 +129,19 @@ public class ImageStoreImpl implements ImageStore {
     }
 
     @Override
-    public Integer addNewToLocation(ImageEntity imageEntity, Integer locationId) {
+    public Integer addNewToLocation(ImageLinkEntity imageLinkEntity, Integer locationId) {
         try {
             userTransaction.begin();
-            entityManager.persist(imageEntity);
+            entityManager.persist(imageLinkEntity);
             ImageByLocation imageByLocation = new ImageByLocation();
-            imageByLocation.setImageId(imageEntity.getId());
+            imageByLocation.setImageId(imageLinkEntity.getId());
             imageByLocation.setLocationId(locationId);
             entityManager.persist(imageByLocation);
             userTransaction.commit();
         } catch (NotSupportedException | RollbackException | HeuristicMixedException | HeuristicRollbackException | SystemException e) {
             e.printStackTrace();
         }
-        return imageEntity.getId();
+        return imageLinkEntity.getId();
     }
 
 }

--- a/src/main/java/com/clueride/domain/image/ImageUploadRequest.java
+++ b/src/main/java/com/clueride/domain/image/ImageUploadRequest.java
@@ -23,7 +23,7 @@ import javax.ws.rs.FormParam;
 
 /**
  * Captures the Form Data for requesting a new file upload, specifically,
- * an {@link ImageEntity} upload.
+ * an {@link ImageLinkEntity} upload.
  */
 public class ImageUploadRequest {
     @FormParam("lat") private Double lat;

--- a/src/main/java/com/clueride/domain/image/ImageWebService.java
+++ b/src/main/java/com/clueride/domain/image/ImageWebService.java
@@ -49,7 +49,7 @@ public class ImageWebService {
     @Path("{locationId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public List<ImageEntity> getImagesForLocation(@PathParam("locationId") Integer locationId) {
+    public List<ImageLinkEntity> getImagesForLocation(@PathParam("locationId") Integer locationId) {
         return imageService.getImagesForLocation(locationId);
     }
 
@@ -65,7 +65,7 @@ public class ImageWebService {
     @Path("upload")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public ImageEntity uploadImage(@MultipartForm ImageUploadRequest imageUploadRequest) {
+    public ImageLinkEntity uploadImage(@MultipartForm ImageUploadRequest imageUploadRequest) {
         return imageService.saveLocationImage(imageUploadRequest);
     }
 

--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -17,20 +17,17 @@
  */
 package com.clueride.domain.location;
 
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import com.clueride.domain.image.ImageEntity;
+import com.clueride.domain.image.ImageLink;
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.loctype.LocationType;
 import com.clueride.domain.puzzle.PuzzleBuilder;
@@ -47,12 +44,11 @@ public class Location {
     private final String description;
     private final LocationType locationType;
     private final Integer nodeId;
-    private final ImageEntity featuredImage;
+    private final ImageLink featuredImage;
     private final Integer googlePlaceId;
     private final LatLon latLon;
     private final ReadinessLevel readinessLevel;
     private List<PuzzleBuilder> puzzleBuilders;
-    private final List<URL> imageUrls;
     private final Integer locationGroupId;
     private final String establishment;
     private final Integer establishmentId;
@@ -73,10 +69,13 @@ public class Location {
         name = builder.getName();
         description = builder.getDescription();
         locationType = builder.getLocationType();
-        featuredImage = builder.getFeaturedImage();
 
-        // If we have multiple images, the ranking goes up
-        imageUrls = builder.getImageUrls();
+        /* OK for Location to be missing Featured Image. */
+        if (builder.getFeaturedImage() != null) {
+            featuredImage = builder.getFeaturedImage().build();
+        } else {
+            featuredImage = null;
+        }
 
         // Featured Level requires the following
         googlePlaceId = builder.getGooglePlaceId();
@@ -163,12 +162,8 @@ public class Location {
         return establishmentId;
     }
 
-    public ImageEntity getFeaturedImage() {
+    public ImageLink getFeaturedImage() {
         return featuredImage;
-    }
-
-    public List<URL> getImageUrls() {
-        return imageUrls;
     }
 
     /**
@@ -195,23 +190,6 @@ public class Location {
     // TODO: not settled on this API
     public Optional<Double> getScorePerTag(String tag) {
         return tagScores.get(tag);
-    }
-
-    // TODO: CA-324 -- Move this logic into the service
-    public void removePuzzle(Integer puzzleId) {
-        synchronized(SYNCH_LOCK) {
-            List<PuzzleBuilder> remainingPuzzles = new ArrayList<>();
-            for (PuzzleBuilder builder : puzzleBuilders) {
-                if (!puzzleId.equals(builder.getId()) && builder != null) {
-                    remainingPuzzles.add(builder);
-                }
-            }
-            this.puzzleBuilders = ImmutableList.copyOf(remainingPuzzles);
-        }
-    }
-
-    public List<PuzzleBuilder> getPuzzleBuilders() {
-        return puzzleBuilders;
     }
 
     @Override

--- a/src/main/java/com/clueride/domain/location/LocationBuilder.java
+++ b/src/main/java/com/clueride/domain/location/LocationBuilder.java
@@ -19,7 +19,6 @@ package com.clueride.domain.location;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,7 @@ import javax.persistence.Transient;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Optional;
 
-import com.clueride.domain.image.ImageEntity;
+import com.clueride.domain.image.ImageLinkEntity;
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.loctype.LocationType;
 import com.clueride.domain.location.loctype.LocationTypeBuilder;
@@ -72,11 +71,13 @@ public class LocationBuilder {
 
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name="featured_image_id")
-    private ImageEntity featuredImage;
+    private ImageLinkEntity featuredImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_type_id")
     private LocationTypeBuilder locationTypeBuilder;
+
+    @Column(name="location_group_id") private Integer locationGroupId;
 
     @Transient
     private LocationType locationType;
@@ -84,8 +85,6 @@ public class LocationBuilder {
     private String locationTypeName;
     @Transient
     private LatLon latLon;
-    @Transient
-    private List<URL> imageUrls;
     @Transient
     private URL featuredImageUrl;
     @Transient private Integer featuredImageId;
@@ -96,7 +95,6 @@ public class LocationBuilder {
 
     @Transient
     private Integer establishmentId;
-    @Column(name="location_group_id") private Integer locationGroupId;
 
     @Transient
     private Map<String,Optional<Double>> tagScores = new HashMap<>();
@@ -123,8 +121,7 @@ public class LocationBuilder {
                 .withLocationType(location.getLocationType())
                 .withNodeId(location.getNodeId())
                 .withLatLon(location.getLatLon())
-                .withFeaturedImage(location.getFeaturedImage())
-                .withImageUrls(location.getImageUrls())
+                .withFeaturedImage(ImageLinkEntity.from(location.getFeaturedImage()))
                 .withEstablishmentId(location.getEstablishment())
                 .withTagScores(location.getTagScores())
                 ;
@@ -284,19 +281,6 @@ public class LocationBuilder {
         return this;
     }
 
-    public List<URL> getImageUrls() {
-        if (imageUrls != null) {
-            return imageUrls;
-        } else {
-            return Collections.emptyList();
-        }
-    }
-
-    public LocationBuilder withImageUrls(List<URL> imageUrls) {
-        this.imageUrls = imageUrls;
-        return this;
-    }
-
     public LatLon getLatLon() {
         return latLon;
     }
@@ -310,11 +294,11 @@ public class LocationBuilder {
     }
 
     /* Image Methods */
-    public ImageEntity getFeaturedImage() {
+    public ImageLinkEntity getFeaturedImage() {
         return featuredImage;
     }
 
-    public LocationBuilder withFeaturedImage(ImageEntity featuredImage) {
+    public LocationBuilder withFeaturedImage(ImageLinkEntity featuredImage) {
         this.featuredImage = featuredImage;
         this.featuredImageId = featuredImage.getId();
         try {
@@ -347,15 +331,6 @@ public class LocationBuilder {
     public LocationBuilder withFeaturedImageUrl(URL featuredImageUrl) {
         this.featuredImageUrl = featuredImageUrl;
         return this;
-    }
-
-    /** Adds to the list of existing images, but not the Featured Image. */
-    public void withImage(ImageEntity image) {
-        try {
-            this.imageUrls.add(new URL(image.getUrl()));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
     }
 
     /* End of Image Methods */
@@ -395,6 +370,7 @@ public class LocationBuilder {
                 .withNodeId(locationBuilder.nodeId)
 //                .withLocationTypeId(locationBuilder.locationTypeId)
                 .withLocationGroupId(locationBuilder.locationGroupId)
-                .withImageUrls(locationBuilder.imageUrls);
+        ;
     }
+
 }


### PR DESCRIPTION
- Renames ImageEntity to ImageLinkEntity.
- Places new (immutable) ImageLink class inside the immutable Location.
- Removes the Image URLs property on the Location.

Defers to the Front End to match up featured Image ID on location against
the full list of imageLinks.