### PR TITLE
SVR-43 Access Token not accepted but cause isn't being logged

### DIFF
--- a/src/main/java/com/clueride/auth/AuthenticationConnectionAuth0.java
+++ b/src/main/java/com/clueride/auth/AuthenticationConnectionAuth0.java
@@ -59,6 +59,7 @@ public class AuthenticationConnectionAuth0 implements AuthenticationConnection {
                 LOGGER.debug(String.format("Raw JSON Response:\n%s", jsonResponse));
                 break;
             case 401:
+                LOGGER.debug("Unauthorized against " + auth0Url);
                 break;
             default:
                 LOGGER.error(String.format(


### PR DESCRIPTION
- Adds logging message when access token rejected.