### PR TITLE
SVR-47 API for List of current Teams

### DIFF
--- a/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
+++ b/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
@@ -45,7 +45,13 @@ public class TeamStoreJpa implements TeamStore {
     @Override
     public List<TeamBuilder> getTeams() {
         LOGGER.info("Retrieving full list of Teams");
-        List<TeamBuilder> builders = entityManager.createQuery("SELECT t FROM teamBuilder t").getResultList();
+        List<TeamBuilder> builders = entityManager.createQuery(
+                "SELECT t FROM teamBuilder t " +
+                "left outer join outing_view o " +
+                "on o.teamId = t.id " +
+                "order by o.courseId, " +
+                "o.scheduledTime desc"
+        ).getResultList();
         return builders;
     }
 

--- a/src/main/java/com/clueride/domain/team/TeamWebService.java
+++ b/src/main/java/com/clueride/domain/team/TeamWebService.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.domain.team;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -33,6 +35,13 @@ import com.clueride.auth.Secured;
 public class TeamWebService {
     @Inject
     private TeamService teamService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Team> getTeams() {
+        return teamService.getTeams();
+    }
 
     @GET
     @Secured


### PR DESCRIPTION
- Adds web service endpoint (service layer through DAO were in place).
- Modifies the Store's query to join the `outing_view` to pickup recent
outings in descending date order to put most recent at top.

This unfortunately will place a newly created team at the bottom, so we
may want to add a creation date column in the future.