### PR TITLE
SVR-48 Need to expire Access Tokens

### DIFF
--- a/src/main/java/com/clueride/auth/access/AccessTokenService.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenService.java
@@ -60,11 +60,6 @@ public interface AccessTokenService {
      */
     String getPrincipalString(String token);
 
-    /**
-     * Clears the cache of all data.
-     */
-    void emptyCache();
-
     void addIdentity(String token, ClueRideIdentity identity);
 
     /** Returns true if this session is known to be active.

--- a/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
@@ -19,6 +19,7 @@ package com.clueride.auth.access;
 
 import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -44,16 +45,11 @@ public class AccessTokenServiceImpl implements AccessTokenService, Serializable 
     @Inject
     private Logger LOGGER;
 
-    @Override
-    // TODO: CA-381 Expire Tokens
-    public void emptyCache() {
-        LOGGER.debug("Clearing the Access Token Cache");
-    }
-
     private static IdentityStore identityStore;
 
     private static LoadingCache<String, ClueRideIdentity> identityCache =
             CacheBuilder.newBuilder()
+                    .expireAfterWrite(24, TimeUnit.HOURS)
                     .build(
                             new CacheLoader<String, ClueRideIdentity>() {
                                 @Override


### PR DESCRIPTION
- Sets the expiration time on the cache to 24 hours.

Also removes an unused `emptyCache()` method.