### PR TITLE
SVR-54 Make the Main Loc Link explicitly Optional

### DIFF
--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -19,10 +19,10 @@ package com.clueride.domain.location;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -56,7 +56,7 @@ public class Location {
     private final Integer locationGroupId;
     private final String establishment;
     private final Integer establishmentId;
-    private final Map<String,Optional<Double>> tagScores;
+    private final Map<String, Optional<Double>> tagScores;
 
     /**
      * Constructor accepting Builder instance.
@@ -80,9 +80,9 @@ public class Location {
             featuredImage = null;
         }
 
-        /* OK for Location to be missing its Main Link -- TODO: officially Optional?. */
-        if (builder.getMainLink() != null) {
-            mainLink = builder.getMainLink().build();
+        /* OK for Location to be missing its Main Link. */
+        if (builder.getMainLink().isPresent()) {
+            mainLink = builder.getMainLink().get().build();
         } else {
             mainLink = null;
         }

--- a/src/main/java/com/clueride/domain/location/LocationBuilder.java
+++ b/src/main/java/com/clueride/domain/location/LocationBuilder.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,7 +39,7 @@ import javax.persistence.Transient;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.google.common.base.Optional;
+import com.sun.istack.internal.Nullable;
 
 import com.clueride.domain.image.ImageLinkEntity;
 import com.clueride.domain.location.latlon.LatLon;
@@ -105,7 +106,8 @@ public class LocationBuilder {
     private Integer establishmentId;
 
     @Transient
-    private Map<String,Optional<Double>> tagScores = new HashMap<>();
+    @Nullable
+    private Map<String, Optional<Double>> tagScores = new HashMap<>();
 
     @Transient
     private String establishment;
@@ -343,10 +345,11 @@ public class LocationBuilder {
         return this;
     }
 
-
     /* End of Image Methods */
-    public LocLinkEntity getMainLink() {
-        return mainLink;
+
+
+    public Optional<LocLinkEntity> getMainLink() {
+        return Optional.ofNullable(this.mainLink);
     }
 
     public LocationBuilder withMainLink(LocLinkEntity locLink) {

--- a/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
@@ -36,6 +36,7 @@ import com.clueride.domain.image.ImageStore;
 import com.clueride.domain.location.latlon.LatLon;
 import com.clueride.domain.location.latlon.LatLonService;
 import com.clueride.domain.location.loclink.LocLink;
+import com.clueride.domain.location.loclink.LocLinkEntity;
 import com.clueride.domain.location.loclink.LocLinkService;
 import com.clueride.domain.location.loctype.LocationType;
 import com.clueride.domain.location.loctype.LocationTypeService;
@@ -113,21 +114,25 @@ public class LocationServiceImpl implements LocationService {
         locationBuilder.withLocationType(locationTypeService.getById(locationBuilder.getLocationTypeId()));
         locationBuilder.withReadinessLevel(scoredLocationService.calculateReadinessLevel(locationBuilder));
 
-        if (locationBuilder.getMainLink().getId() == null) {
-            try {
-                LocLink locLink  = locLinkService.createNewLocationLink(locationBuilder.getMainLink());
-                locationBuilder.withLocLink(locLink);
-            } catch (MalformedURLException e) {
-                e.printStackTrace();
-            }
-        } else if (locationBuilder.getMainLink().getLink().length() > 0) {
-            try {
-                LocLink locLink = locLinkService.getLocLinkByUrl(
-                        locationBuilder.getMainLink().getLink()
-                );
-                locationBuilder.withLocLink(locLink);
-            } catch (MalformedURLException e) {
-                e.printStackTrace();
+        // TODO: SVR-36 and this too -- unit testing will help flatten this
+        if (locationBuilder.getMainLink().isPresent()) {
+            LocLinkEntity proposedLocLinkEntity = locationBuilder.getMainLink().get();
+            if (proposedLocLinkEntity.getId() == null) {
+                try {
+                    LocLink locLink  = locLinkService.createNewLocationLink(proposedLocLinkEntity);
+                    locationBuilder.withLocLink(locLink);
+                } catch (MalformedURLException e) {
+                    e.printStackTrace();
+                }
+            } else if (proposedLocLinkEntity.getLink().length() > 0) {
+                try {
+                    LocLink locLink = locLinkService.getLocLinkByUrl(
+                            proposedLocLinkEntity.getLink()
+                    );
+                    locationBuilder.withLocLink(locLink);
+                } catch (MalformedURLException e) {
+                    e.printStackTrace();
+                }
             }
         }
 


### PR DESCRIPTION
- Changes the Builder's return type from LocLink to Optional<LocLink>.
- Replaces tests for null with tests for `isPresent()`.

- Hibernate likes an actual object where it can place the null -- an @Nullable field.
- The real issue comes when working with this value -- which may or may not be present -- and allowing that test to occur instead of a null value check.