### PR TITLE
SVR-60 Establish BadgeOS Session

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.3</version>
+            <version>4.4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/clueride/badgeos/BadgeOSCredentials.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSCredentials.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+package com.clueride.badgeos;
+
+
+import javax.annotation.concurrent.Immutable;
+import javax.inject.Inject;
+
+import com.clueride.config.ConfigService;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Values used to populate the Login Form for BadgeOS.
+ *
+ * Sensitive information is kept in configuration files outside
+ * of the VCS.
+ */
+@Immutable
+public class BadgeOSCredentials {
+    private final String log;
+    private final String pwd;
+    private final static String WP_SUBMIT = "Log In";
+
+    @Inject
+    public BadgeOSCredentials(
+            ConfigService configService
+    ) {
+        this.log = requireNonNull(configService.getBadgeOSAccountName());
+        this.pwd = requireNonNull(configService.getBadgeOSPassword());
+    }
+
+    public String getLog() {
+        return log;
+    }
+
+    public String getPwd() {
+        return pwd;
+    }
+
+    public String getWpSubmit() {
+        return WP_SUBMIT;
+    }
+
+}

--- a/src/main/java/com/clueride/badgeos/BadgeOSSessionService.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSSessionService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+package com.clueride.badgeos;
+
+import org.apache.http.client.CookieStore;
+
+/**
+ * Defines operations against the BadgeOS Session.
+ */
+public interface BadgeOSSessionService {
+
+    /**
+     * Refreshes the session cookies for BadgeOS sessions.
+     */
+    void refreshSession();
+
+    /**
+     * Retrieves a Nonce from BadgeOS suitable for awarding achievements.
+     * @return String representation of the Nonce for Awarding achievements.
+     */
+    Nonce getAwardNonce();
+
+    /**
+     * Retrieves a Nonce from BadgeOS suitable for revoking an existing achievement.
+     * @return String representation of the Nonce for Deletion.
+     */
+    Nonce getRevokeNonce();
+
+    /**
+     * Retrieves the set of BadgeOS Session cookies.
+     * Generally used for diagnostics; provides sensitive information.
+     * @return CookieStore from having established a BadgeOS Session.
+     */
+    CookieStore getSessionCookies();
+
+}

--- a/src/main/java/com/clueride/badgeos/BadgeOSSessionServiceImpl.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSSessionServiceImpl.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+package com.clueride.badgeos;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.http.Consts;
+import org.apache.http.HttpEntity;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+
+import com.clueride.config.ConfigService;
+
+/**
+ * Implementation of {@link BadgeOSSessionService}.
+ *
+ * Uses credentials to login to BadgeOS and from the response, picks up both
+ * a set of Cookies for use in future sessions as well as a set of Nonces that
+ * are required for future calls. These nonces are then available to be retrieved for use
+ * within a session mediated by the cookies.
+ */
+public class BadgeOSSessionServiceImpl implements BadgeOSSessionService {
+    @Inject
+    private Logger LOGGER;
+
+    private final BadgeOSCredentials badgeOSCredentials;
+    private final String loginUrlAsString;
+
+    /** Populated with session cookies which are "re-baked" when needed. */
+    // TODO: This will need to be refreshed/re-baked periodically.
+    private static HttpClientContext badgeOSContext = null;
+    private static CookieStore cookieStore = null;
+    private static Map<NonceType, Nonce> nonces = null;
+
+    @Inject
+    public BadgeOSSessionServiceImpl(
+            BadgeOSCredentials badgeOSCredentials,
+            ConfigService configService
+    ) {
+        this.loginUrlAsString = configService.getBadgeOSLoginUrlAsString();
+        this.badgeOSCredentials = badgeOSCredentials;
+    }
+
+    @Override
+    public void refreshSession() {
+        /* Establish Context if needed. */
+        badgeOSContext = establishContext();
+
+        retrieveUserAchievementNonces();
+
+    }
+
+    /**
+     * After getting a new set of cookies, we also make sure we have a new set
+     * of Nonces.
+     */
+    private void retrieveUserAchievementNonces() {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+
+            /* Prepare for the next POST to pick up the Nonces. */
+            HttpGet userGet = new HttpGet(
+                    "https://clueride.com/wp-admin/user-edit.php?user_id=47"
+            );
+            LOGGER.info("User Page Request: \n{}", userGet.getRequestLine());
+
+            CloseableHttpResponse userGetResponse = httpClient.execute(userGet, badgeOSContext);
+            LOGGER.info("User Page Response: {}", userGetResponse.getStatusLine());
+            String userGetResponseAsString = EntityUtils.toString(userGetResponse.getEntity());
+
+            /* Pull out the Cookies. */
+            cookieStore = badgeOSContext.getCookieStore();
+
+            /* Pull out the Nonces. */
+            nonces = retrieveNonces(userGetResponseAsString);
+
+        } catch (IOException e) {
+            LOGGER.error("Problem connecting to BadgeOS");
+            e.printStackTrace();
+        }
+
+    }
+
+    @Override
+    public Nonce getAwardNonce() {
+        if (nonces == null) {
+            refreshSession();
+        }
+
+        assert nonces != null;
+        return nonces.get(NonceType.AWARD_ACHIEVEMENT);
+    }
+
+    @Override
+    public Nonce getRevokeNonce() {
+        if (nonces == null) {
+            refreshSession();
+        }
+
+        assert nonces != null;
+        return nonces.get(NonceType.REVOKE_ACHIEVEMENT);
+    }
+
+    @Override
+    public CookieStore getSessionCookies() {
+        return cookieStore;
+    }
+
+    /**
+     * Creates a new Context populated by logging into WordPress if we haven't
+     * already done so.
+     *
+     * @return Either the existing context for WordPress, or establish a new one
+     * if it doesn't exist.
+     */
+    private HttpClientContext establishContext() {
+        /* Use pre-established context if it is available. */
+        if (badgeOSContext != null) {
+            return badgeOSContext;
+        }
+
+        HttpClientContext context = HttpClientContext.create();
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+
+            /* Assemble the Login Form's data entity to be posted. */
+            List<NameValuePair> formElements = new ArrayList<>();
+            formElements.add(new BasicNameValuePair("log", badgeOSCredentials.getLog()));
+            formElements.add(new BasicNameValuePair("pwd", badgeOSCredentials.getPwd()));
+            formElements.add(new BasicNameValuePair("wp-submit", badgeOSCredentials.getWpSubmit()));
+            formElements.add(new BasicNameValuePair("testcookie", "1"));
+
+            /* This endpoint may change as we evolve, but is suitable for proving out the concepts. */
+            formElements.add(new BasicNameValuePair(
+                    "redirect_to",
+                    "https://clueride.com/wp-admin/user-edit.php?user_id=47"
+            ));
+
+            HttpEntity loginEntity = new UrlEncodedFormEntity(formElements, Consts.UTF_8);
+
+            /* Create and Invoke the URL for logging in. */
+            HttpPost loginPost = new HttpPost(loginUrlAsString);
+            loginPost.setEntity(loginEntity);
+            LOGGER.debug("Connecting to BadgeOS: \n{}", loginPost.getRequestLine());
+
+            CloseableHttpResponse response = httpClient.execute(loginPost, context);
+            LOGGER.debug("login.php Status: {}", response.getStatusLine());
+            response.close();
+        } catch (IOException e) {
+            LOGGER.error("Problem connecting to BadgeOS");
+            throw(new RuntimeException("Unable to connect to BadgeOS", e));
+        }
+        return context;
+    }
+
+    /**
+     * Given the User Page, retrieve the Nonces needed to award an achievement.
+     *
+     * @param userGetResponseAsString Entire text of the User Edit page from WordPress / BadgeOS.
+     * @return Map of the relevant (and desired) Nonces found on the page.
+     */
+    private Map<NonceType, Nonce> retrieveNonces(String userGetResponseAsString) {
+        boolean haveAwardNonce = false;
+        boolean haveRevokeNonce = false;
+
+        Map<NonceType, Nonce> map = new HashMap<>();
+
+        String[] lines = userGetResponseAsString.split("\n");
+        for (String line : lines) {
+            if (line.contains("action=award")) {
+                LOGGER.debug("Found Award Nonce");
+                map.put(NonceType.AWARD_ACHIEVEMENT, nonceFromLine(line, NonceType.AWARD_ACHIEVEMENT));
+                haveAwardNonce = true;
+            }
+            if (line.contains("action=revoke")) {
+                LOGGER.debug("Found Revoke Nonce");
+                map.put(NonceType.REVOKE_ACHIEVEMENT, nonceFromLine(line, NonceType.REVOKE_ACHIEVEMENT));
+                haveRevokeNonce = true;
+            }
+            if (haveAwardNonce && haveRevokeNonce) {
+                return map;
+            }
+        }
+        LOGGER.error("Unable to find nonces for both Award and Revoke");
+        return map;
+    }
+
+    private Nonce nonceFromLine(String line, NonceType nonceType) {
+        String actionPortion = line.substring(line.indexOf("action"));
+        String field = actionPortion.substring(
+                actionPortion.indexOf("_wpnonce"),
+                actionPortion.indexOf("\">")
+        );
+        LOGGER.debug("Nonce field: {}", field);
+
+        String nonceValue = field.substring(field.indexOf("=")+1);
+        return new Nonce(nonceType, nonceValue);
+    }
+
+}

--- a/src/main/java/com/clueride/badgeos/BadgeOSWebService.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSWebService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+package com.clueride.badgeos;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.clueride.auth.Secured;
+
+/**
+ * Temporary web interface for exercising the BadgeOSSessionService.
+ */
+@Path("/badgeos")
+public class BadgeOSWebService {
+    @Inject
+    private BadgeOSSessionService badgeOSSessionService;
+
+    @GET
+    @Secured
+    @Path("award-nonce")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Nonce getAwardNonce() {
+        return badgeOSSessionService.getAwardNonce();
+    }
+
+    @GET
+    @Secured
+    @Path("revoke-nonce")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Nonce getRevokeNonce() {
+        return badgeOSSessionService.getRevokeNonce();
+    }
+
+}

--- a/src/main/java/com/clueride/badgeos/Nonce.java
+++ b/src/main/java/com/clueride/badgeos/Nonce.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+package com.clueride.badgeos;
+
+import net.jcip.annotations.Immutable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Defines a Type for the Nonce which is simply a String.
+ *
+ * This also carries the type of Nonce so we can tell what use
+ * this nonce can be put to.
+ */
+@Immutable
+public class Nonce {
+    public NonceType getNonceType() {
+        return nonceType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private final NonceType nonceType;
+    private final String value;
+
+    public Nonce(NonceType nonceType, String value) {
+        this.nonceType = nonceType;
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+}

--- a/src/main/java/com/clueride/badgeos/NonceType.java
+++ b/src/main/java/com/clueride/badgeos/NonceType.java
@@ -1,0 +1,22 @@
+package com.clueride.badgeos;/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/20/19.
+ */
+
+public enum NonceType {
+    AWARD_ACHIEVEMENT,
+    REVOKE_ACHIEVEMENT
+}

--- a/src/main/java/com/clueride/config/ConfigService.java
+++ b/src/main/java/com/clueride/config/ConfigService.java
@@ -58,4 +58,13 @@ public interface ConfigService {
     /** Base Directory for images on the Image Server. */
     String getImageBaseDirectory();
 
+    /** Account Name for the BadgeOS System account assigned to this Server. */
+    String getBadgeOSAccountName();
+
+    /** Password for the BadgeOS account assigned to this server. */
+    String getBadgeOSPassword();
+
+    /** URL of the BadgeOS Login page. */
+    String getBadgeOSLoginUrlAsString();
+
 }

--- a/src/main/java/com/clueride/config/ConfigServiceImpl.java
+++ b/src/main/java/com/clueride/config/ConfigServiceImpl.java
@@ -92,4 +92,19 @@ public class ConfigServiceImpl implements ConfigService {
         return get("clueride.image.baseDirectory");
     }
 
+    @Override
+    public String getBadgeOSAccountName() {
+        return get("badgeos.account");
+    }
+
+    @Override
+    public String getBadgeOSPassword() {
+        return get("badgeos.password");
+    }
+
+    @Override
+    public String getBadgeOSLoginUrlAsString() {
+        return get("badgeos.loginUrl");
+    }
+
 }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -12,3 +12,7 @@ log4j.appender.APP_LOG.layout=org.apache.log4j.PatternLayout
 # This format matches what WildFly is using (except for full date):
 log4j.appender.APP_LOG.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t): %m%n
 
+
+# Logging config for HttpClient (see http://hc.apache.org/httpcomponents-client-4.4.x/logging.html)
+log4j.logger.org.apache.http=DEBUG, APP_LOG
+log4j.logger.org.apache.http.wire=ERROR, APP_LOG

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -64,6 +64,12 @@ clueride {
 
 }
 
+badgeos {
+    account = "replace with Word Press account for application admin"
+    password = "replace with correct password"
+    loginUrl = "https://clueride.com/wp-login.php"
+}
+
 sse {
     # Defines the Host used for broadcasting SSE.
     host = "dorado:6543"


### PR DESCRIPTION
- Adds new BadgeOS Service with webservice that supports retrieving
Nonces from a WordPress session that we've logged into using credentials
stored in the app server.

This also amended the log4j.properties to allow debugging of the connection code.

Adds more complete set of dependencies for HttpComponents.