### PR TITLE
SVR-67 Implement awarding visits to Close-Ended Theme Attractions

### DIFF
--- a/src/main/java/com/clueride/aop/badge/MethodName.java
+++ b/src/main/java/com/clueride/aop/badge/MethodName.java
@@ -1,0 +1,54 @@
+package com.clueride.aop.badge;/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/26/19.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines the recognized values for Badge Event Method Names.
+ */
+public enum MethodName {
+
+    ARRIVAL("arrival"),
+    ADD_NEW_TO_LOCATION("addNewToLocation"),    // New Image
+    COURSE_COMPLETED("courseCompleted"),
+    POST_ANSWER_FOR_SESSION("postAnswerForSession"),
+    TEAM_ASSEMBLED("teamAssembled"),
+    UPDATE_LOCATION("updateLocation"),
+    UPLOAD_IMAGE("uploadImage"),
+    ;
+
+    public final String methodName;
+
+    private static final Map<String,MethodName> BY_METHOD_NAME = new HashMap<>();
+
+    static {
+        for (MethodName m : values()) {
+            BY_METHOD_NAME.put(m.methodName, m);
+        }
+    }
+
+    MethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public static MethodName fromMethodName(String methodName) {
+        return BY_METHOD_NAME.get(methodName);
+    }
+
+}

--- a/src/main/java/com/clueride/badgeos/BadgeOSSessionService.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSSessionService.java
@@ -25,6 +25,17 @@ import org.apache.http.client.CookieStore;
 public interface BadgeOSSessionService {
 
     /**
+     * Recognize an Achievement for the User.
+     *
+     * This is the beginning of an asynchronous operation that will eventually
+     * either be successful or not.
+     *
+     * @param userId Word Press unique identifier.
+     * @param achievementId Corresponds to a specific Step or Badge within BadgeOS.
+     */
+    void awardAchievement(Integer userId, Integer achievementId);
+
+    /**
      * Refreshes the session cookies for BadgeOS sessions.
      */
     void refreshSession();

--- a/src/main/java/com/clueride/badgeos/BadgeOSSessionServiceImpl.java
+++ b/src/main/java/com/clueride/badgeos/BadgeOSSessionServiceImpl.java
@@ -73,6 +73,29 @@ public class BadgeOSSessionServiceImpl implements BadgeOSSessionService {
     }
 
     @Override
+    public void awardAchievement(Integer userId, Integer achievementId) {
+        Nonce nonce = getAwardNonce();
+        String urlString = String.format("https://clueride.com/wp-admin/user-edit.php" +
+                "?user_id=%d" +
+                "&wp_http_referer=/wp-admin/users.php" +
+                "&action=award" +
+                "&achievement_id=%d" +
+                "&_wpnonce=%s",
+                userId,
+                achievementId,
+                nonce.getValue()
+        );
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet httpGet = new HttpGet(urlString);
+            CloseableHttpResponse userGetResponse = httpClient.execute(httpGet, badgeOSContext);
+        } catch (IOException e) {
+            LOGGER.error("Problem connecting to BadgeOS");
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public void refreshSession() {
         /* Establish Context if needed. */
         badgeOSContext = establishContext();

--- a/src/main/java/com/clueride/domain/account/member/Member.java
+++ b/src/main/java/com/clueride/domain/account/member/Member.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class Member implements Serializable {
     private int id;
+    private Integer badgeOSId;
     private String displayName;
     private String firstName;
     private String lastName;
@@ -46,6 +47,7 @@ public class Member implements Serializable {
 
     public Member(MemberBuilder builder) {
         this.id = builder.getId();
+        this.badgeOSId = builder.getBadgeOSId();
         this.displayName = builder.getDisplayName();
         this.firstName = builder.getFirstName();
         this.lastName = builder.getLastName();
@@ -58,16 +60,12 @@ public class Member implements Serializable {
         return id;
     }
 
-    public void withId(Integer id) {
-        this.id = id;
+    public Integer getBadgeOSId() {
+        return badgeOSId;
     }
 
     public String getDisplayName() {
         return displayName;
-    }
-
-    public void withDisplayName(String displayName) {
-        this.displayName = displayName;
     }
 
     public String getFirstName() {

--- a/src/main/java/com/clueride/domain/account/member/MemberBuilder.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberBuilder.java
@@ -41,6 +41,9 @@ public class MemberBuilder {
     @SequenceGenerator(name = "member_pk_sequence", sequenceName = "member_id_seq", allocationSize = 1)
     private Integer id;
 
+    @Column(name = "badgeos_id")
+    private Integer badgeOSId;
+
     @Column(name = "display_name")
     private String displayName;
     @Column(name = "first_name")
@@ -72,6 +75,7 @@ public class MemberBuilder {
         requireNonNull(member);
         return builder()
                 .withId(member.getId())
+                .withBadgeOSId(member.getBadgeOSId())
                 .withPhone(member.getPhoneNumber())
                 .withFirstName(member.getFirstName())
                 .withLastName(member.getLastName())
@@ -101,6 +105,15 @@ public class MemberBuilder {
 
     public MemberBuilder withId(Integer id) {
         this.id = id;
+        return this;
+    }
+
+    public Integer getBadgeOSId() {
+        return badgeOSId;
+    }
+
+    public MemberBuilder withBadgeOSId(Integer badgeOSId) {
+        this.badgeOSId = badgeOSId;
         return this;
     }
 

--- a/src/main/java/com/clueride/domain/account/member/MemberService.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberService.java
@@ -25,7 +25,7 @@ import javax.mail.internet.InternetAddress;
 import com.clueride.auth.identity.ClueRideIdentity;
 
 /**
- * Provides business-layer services for Members and their Badges.
+ * Provides business-layer services for Clue Ride Members.
  */
 public interface MemberService {
 

--- a/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberServiceImpl.java
@@ -93,7 +93,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    // TODO: CA-405 connect this more tightly (SVR-37 addresses this in part).
+    // TODO: CA-405 connects the Image URL more tightly (SVR-37 addresses this in part).
     public Member createNewMember(ClueRideIdentity clueRideIdentity) {
         MemberBuilder memberBuilder = memberStore.addNew(
                 MemberBuilder.from(clueRideIdentity)

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalServiceImpl.java
@@ -56,7 +56,7 @@ public class BadgeOsPrincipalServiceImpl implements BadgeOsPrincipalService, Ser
     @Override
     public BadgeOsPrincipal getBadgeOsPrincipal(InternetAddress emailAddress) {
         requireNonNull(emailAddress, "Email Address must be non-null");
-        LOGGER.debug("Looking up Principal for {}", emailAddress.toString());
+        LOGGER.debug("Looking up BadgeOS Principal for {}", emailAddress.toString());
 
         return badgeOsPrincipalStore.getBadgeOsPrincipalForEmailAddress(
                 emailAddress

--- a/src/main/java/com/clueride/domain/achievement/award/AwardAchievementService.java
+++ b/src/main/java/com/clueride/domain/achievement/award/AwardAchievementService.java
@@ -13,28 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 6/16/19.
+ * Created by jett on 7/26/19.
  */
-package com.clueride.domain.step;
-
-import java.util.List;
+package com.clueride.domain.achievement.award;
 
 /**
- * Defines operations on {@link Step} instances.
+ * Defines operations for awarding achievements.
  */
-public interface StepService {
+public interface AwardAchievementService {
 
     /**
-     * Retrieves full list of Steps.
-     * @return Complete List of Steps.
+     * Award the Arrival Achievement for the Attraction specified in the BadgeEvent.
+     *
+     * @param memberId WordPress identifier for the User being awarded the arrival.
+     * @param nextLocationName Name of the Attraction arrived.
+     * @param locationId ID of the Attraction arrived.
      */
-    List<Step> getAllSteps();
-
-    /**
-     * Retrieves list of Steps for a given Badge.
-     * @param badgeId unique identifier for a Badge.
-     * @return List of the steps just for the given Badge.
-     */
-    List<Step> getAllStepsForBadge(int badgeId);
+    void awardArrival(
+            Integer memberId,
+            String nextLocationName,
+            Integer locationId
+    );
 
 }

--- a/src/main/java/com/clueride/domain/achievement/award/AwardAchievementServiceImpl.java
+++ b/src/main/java/com/clueride/domain/achievement/award/AwardAchievementServiceImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/27/19.
+ */
+package com.clueride.domain.achievement.award;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import com.clueride.badgeos.BadgeOSSessionService;
+import com.clueride.domain.achievement.map.ArrivalStepsMapService;
+
+/**
+ * Implementation of {@link AwardAchievementService}.
+ */
+public class AwardAchievementServiceImpl implements AwardAchievementService {
+    @Inject
+    private Logger LOGGER;
+
+    private final ArrivalStepsMapService arrivalStepsMapService;
+    private final BadgeOSSessionService badgeOSSessionService;
+
+    private static Map<Integer, List<Integer>> arrivalStepsMap;
+
+    @Inject
+    public AwardAchievementServiceImpl(
+            ArrivalStepsMapService arrivalStepsMapService,
+            BadgeOSSessionService badgeOSSessionService
+    ) {
+        this.arrivalStepsMapService = arrivalStepsMapService;
+        this.badgeOSSessionService = badgeOSSessionService;
+        arrivalStepsMap = populateArrivalStepsMap();
+    }
+
+    @Override
+    public void awardArrival(
+            Integer badgeOSId,
+            String attractionName,
+            Integer locationId
+    ) {
+        if (StringUtils.isEmpty(attractionName)) {
+            LOGGER.error("awardArrival: Missing the Attraction's Name");
+            throw new RuntimeException("awardArrival: Missing the Attraction's Name");
+        }
+
+        if (!arrivalStepsMap.containsKey(locationId)) {
+            LOGGER.warn("Arrival at Attraction {} shows no achievements", attractionName);
+            return;
+        }
+
+        List<Integer> arrivalStepIds = arrivalStepsMap.get(locationId);
+
+        for (Integer stepId : arrivalStepIds) {
+            awardAchievement(badgeOSId, stepId);
+        }
+
+    }
+
+    /**
+     * Populate the map from an Attraction to the list of achievements awarded when
+     * visiting that Attraction.
+     *
+     * @return Map from Attraction's Name over to Integer Step ID.
+     */
+    private Map<Integer, List<Integer>> populateArrivalStepsMap() {
+        Map<Integer, List<Integer>> arrivalStepsMap = arrivalStepsMapService.loadArrivalStepsMap();
+        arrivalStepsMapService.validate(Collections.emptyList());
+        return arrivalStepsMap;
+    }
+
+    /**
+     * Given the WordPress Badge OS ID and the Achievement ID, award the achievement to the user.
+     *
+     * @param badgeOSId WordPress User ID.
+     * @param achievementId ID of the achievement to award.
+     */
+    private void awardAchievement(Integer badgeOSId, int achievementId) {
+        badgeOSSessionService.awardAchievement(badgeOSId, achievementId);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepEntity.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepEntity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/29/19.
+ */
+package com.clueride.domain.achievement.map;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Persistable Entity for the Many-to-Many map from Attraction to the Step
+ * awarded when arriving at the Attraction.
+ *
+ * In the database, there are generally multiple awarded achievements (Steps)
+ * per Location ID. To turn this into a map, the records are keyed by the Location ID
+ * and the multiple Steps are collected in a List.
+ *
+ * This is starting out as Read-Only until we come up with a more automated way to
+ * maintain the records in the table.
+ */
+@Entity
+@Table(name = "arrival_to_step_map")
+public class ArrivalStepEntity {
+    @Id
+    private int id;
+
+    @Column(name = "location_id")
+    private int locationId;
+
+    @Column(name = "step_id")
+    private int stepId;
+
+    @Column(name = "badge_id")
+    private int badgeId;
+
+    public int getId() {
+        return id;
+    }
+
+    public int getLocationId() {
+        return locationId;
+    }
+
+    public int getStepId() {
+        return stepId;
+    }
+
+    public int getBadgeId() {
+        return badgeId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStore.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStore.java
@@ -13,28 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 6/16/19.
+ * Created by jett on 7/29/19.
  */
-package com.clueride.domain.step;
+package com.clueride.domain.achievement.map;
 
 import java.util.List;
 
 /**
- * Defines operations on {@link Step} instances.
+ * Defines Persistence operations on {@link ArrivalStepEntity} records
  */
-public interface StepService {
+public interface ArrivalStepStore {
 
     /**
-     * Retrieves full list of Steps.
-     * @return Complete List of Steps.
+     * Reads all the records in the Map table.
+     * @return List of all {@link ArrivalStepEntity} instances.
      */
-    List<Step> getAllSteps();
-
-    /**
-     * Retrieves list of Steps for a given Badge.
-     * @param badgeId unique identifier for a Badge.
-     * @return List of the steps just for the given Badge.
-     */
-    List<Step> getAllStepsForBadge(int badgeId);
+    List<ArrivalStepEntity> getAllRecords();
 
 }
+

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStoreJpa.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStoreJpa.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 6/16/19.
+ * Created by jett on 7/29/19.
  */
-package com.clueride.domain.step;
+package com.clueride.domain.achievement.map;
 
 import java.util.List;
 
@@ -26,35 +26,24 @@ import javax.persistence.PersistenceContext;
 import org.slf4j.Logger;
 
 /**
- * JPA implementation of {@link StepStore}.
+ * JPA implementation of {@link ArrivalStepStore}.
  */
-public class StepStoreJpa implements StepStore {
+public class ArrivalStepStoreJpa implements ArrivalStepStore {
+
     @Inject
     private Logger LOGGER;
 
-    @PersistenceContext(unitName = "badgeOS")
+    @PersistenceContext(unitName = "clueride")
     private EntityManager entityManager;
 
     @Override
-    public List<StepEntity> getAllSteps() {
+    public List<ArrivalStepEntity> getAllRecords() {
         LOGGER.debug("Retrieving all Steps");
-        List<StepEntity> entities;
+        List<ArrivalStepEntity> entities;
         entities = entityManager.createQuery(
-                "SELECT s FROM StepEntity s"
+                "SELECT s FROM ArrivalStepEntity s"
         ).getResultList();
         return entities;
     }
-
-    @Override
-    public Iterable<? extends StepEntity> getStepsForBadge(int badgeId) {
-        LOGGER.debug("Retrieving Steps for Badge ID {}", badgeId);
-        List<StepEntity> entities = entityManager.createQuery(
-                "SELECT s FROM StepEntity s WHERE s.parentId = :badgeId"
-        ).setParameter(
-                "badgeId", badgeId
-        ).getResultList();
-        return entities;
-    }
-
 
 }

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepsMapService.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepsMapService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/28/19.
+ */
+package com.clueride.domain.achievement.map;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines operations on a Map from Arrival events to the BadgeOS Steps
+ * that should be awarded for each Arrival.
+ */
+public interface ArrivalStepsMapService {
+
+    /**
+     * Builds a Map from an Attraction over to the Step whose
+     * achievement IDs are used to award arriving at that Attraction.
+     * @return Map from Attraction Name to a List of Integer Achievement IDs.
+     */
+    Map<Integer, List<Integer>> buildArrivalStepsMap();
+
+    /**
+     * Retrieves Map (which may be cached).
+     * @return Map from Attraction Name to a List of Integer Achievement IDs.
+     */
+    Map<Integer, List<Integer>> loadArrivalStepsMap();
+
+    /**
+     * Checks that each Attraction in the list has been mapped to an Achievement ID.
+     * This can be run against a course to see if there are any Attractions that
+     * do not have a theme assigned.
+     * @param attractionIds List of Attraction IDs to be validated.
+     * @return number of Attractions in the list that do not have an Achievement ID.
+     */
+    int validate(List<Integer> attractionIds);
+
+}

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepsMapServiceImpl.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepsMapServiceImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/28/19.
+ */
+package com.clueride.domain.achievement.map;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+
+import com.clueride.domain.badge.features.BadgeFeatures;
+import com.clueride.domain.badge.features.BadgeFeaturesService;
+import com.clueride.domain.location.Location;
+import com.clueride.domain.location.LocationService;
+import com.clueride.domain.step.Step;
+import com.clueride.domain.step.StepService;
+
+/**
+ * Implementation of {@link ArrivalStepsMapService}.
+ */
+public class ArrivalStepsMapServiceImpl implements ArrivalStepsMapService {
+    @Inject
+    private Logger LOGGER;
+
+    private final LocationService locationService;
+    private final BadgeFeaturesService badgeFeaturesService;
+    private final StepService stepService;
+    private final ArrivalStepStore arrivalStepStore;
+
+    private static Map<Integer, List<Integer>> arrivalStepsMap = new HashMap<>();
+
+    @Inject
+    public ArrivalStepsMapServiceImpl(
+            LocationService locationService,
+            BadgeFeaturesService badgeFeaturesService,
+            StepService stepService,
+            ArrivalStepStore arrivalStepStore
+    ) {
+        this.locationService = locationService;
+        this.badgeFeaturesService = badgeFeaturesService;
+        this.stepService = stepService;
+        this.arrivalStepStore = arrivalStepStore;
+    }
+
+    @Override
+    public Map<Integer, List<Integer>> buildArrivalStepsMap() {
+        LOGGER.debug("Re-Building Arrival - Steps Map");
+        /* Flush out any existing copy, we're rebuilding. */
+        arrivalStepsMap = new HashMap<>();
+
+        List<Location> locations = locationService.getThemeLocations();
+        Map<String, Integer> locationIdPerName = new HashMap<>();
+        for (Location location : locations) {
+            locationIdPerName.put(location.getName(), location.getId());
+        }
+        List<BadgeFeatures> badgeFeaturesList = badgeFeaturesService.getThemedBadgeFeatures();
+        List<Step> steps = new ArrayList<>();
+        for (BadgeFeatures badgeFeatures : badgeFeaturesList) {
+            steps.addAll(stepService.getAllStepsForBadge(badgeFeatures.getId()));
+        }
+
+        for (Step step : steps) {
+            if (locationIdPerName.containsKey(step.getName())) {
+                LOGGER.info("Found Step {} for Location {}", step.getId(), step.getName());
+                arrivalStepsMap.put(locationIdPerName.get(step.getName()), Collections.singletonList(step.getId()));
+            } else {
+                LOGGER.info("No match found for Step {}", step);
+            }
+        }
+        return arrivalStepsMap;
+    }
+
+    @Override
+    public Map<Integer, List<Integer>> loadArrivalStepsMap() {
+        LOGGER.debug("Loading Arrival -> Steps Map");
+        /* Flush out any existing copy, we're rebuilding. */
+        arrivalStepsMap = new HashMap<>();
+
+        List<ArrivalStepEntity> arrivalStepEntityList = arrivalStepStore.getAllRecords();
+        for (ArrivalStepEntity arrivalStepEntity : arrivalStepEntityList) {
+            int locationId = arrivalStepEntity.getLocationId();
+            int stepId = arrivalStepEntity.getStepId();
+            List<Integer> attractionStepIds;
+            if (arrivalStepsMap.containsKey(arrivalStepEntity.getLocationId())) {
+                attractionStepIds = arrivalStepsMap.get(locationId);
+            } else {
+                attractionStepIds = new ArrayList<>();
+                arrivalStepsMap.put(locationId, attractionStepIds);
+            }
+            attractionStepIds.add(stepId);
+        }
+        return arrivalStepsMap;
+    }
+
+    @Override
+    public int validate(List<Integer> attractionIds) {
+        int missingLocations = 0;
+
+        List<Location> locations = locationService.getThemeLocations();
+        Map<Integer, String> locationPerId = new HashMap<>();
+        for (Location location : locations) {
+            locationPerId.put(location.getId(), location.getName());
+        }
+
+        List<BadgeFeatures> badgeFeaturesList = badgeFeaturesService.getThemedBadgeFeatures();
+        Map<Integer, String> stepNamePerId = new HashMap<>();
+        for (BadgeFeatures badgeFeatures : badgeFeaturesList) {
+            List<Step> steps = stepService.getAllStepsForBadge(badgeFeatures.getId());
+            for (Step step : steps) {
+                stepNamePerId.put(step.getId(), step.getName());
+            }
+        }
+
+        // TODO: Sort out if I really want to pass in the list of Attraction IDs
+//        for (Integer attractionId : attractionIds) {
+        for (Integer attractionId : locationPerId.keySet()) {
+            if (arrivalStepsMap.containsKey(attractionId)) {
+                LOGGER.info("Found Step(s) for Location ID {} ({}): {} ({})",
+                        attractionId,
+                        locationPerId.get(attractionId),
+                        arrivalStepsMap.get(attractionId).get(0),
+                        stepNamePerId.get(arrivalStepsMap.get(attractionId).get(0))
+                );
+            } else {
+                missingLocations++;
+                LOGGER.warn("No Step found for Location ID {} ({})",
+                        attractionId,
+                        locationPerId.get(attractionId)
+                );
+            }
+        }
+
+        return missingLocations;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/achievement/map/README.md
+++ b/src/main/java/com/clueride/domain/achievement/map/README.md
@@ -1,0 +1,35 @@
+# Achievement Map Package
+This contains code that maps portions of a Badge Event to the Achievement to be awarded.
+
+Different Events take different criteria, and thus build maps with different keys.
+
+## Responsibilities
+* Knows how to retrieve the relevant records.
+  * Source Records by Badge Type.
+  * Achievement Records by Badge.
+* Builds a Map from an element in the Badge Event (Attraction Name, for example) to a list of specific achievement IDs.
+* Cache these values per outing -- they need to remain unchanged throughout the course of an outing.
+
+Some maps are one-to-one with a given event. For example, if we see a Course Completed event, we always 
+award the achievement against a single ID in BadgeOS.
+
+## Collaborations
+* *Attraction ID* - For the Arrival at an Attraction event, the Attraction ID provides a unique identifier corresponding to the full details for a given record in the `location` table.
+* *Location Type* - The `location` table carries an ID for the *primary* Location Type which corresponds closely with a Theme. There may not be an exact match for every Location. There may be more than one Location Type for a given Location, but first cut is to recognize a single location type per location arrival.
+* *Themes* - correspond closely with Badges, either Close-Ended or Open-Ended. There may not be an official badge awarded for every location type. This map is the operational definition of which awards will be available since if we don't have an achievement in BadgeOS that we can award, there won't be a record in the map.
+* *BadgeService* - A list of the available Badges will also have for each Badge the list of children steps.
+* *AchievementMap* - A 'map' table that holds a record for each location and the achievement it corresponds to.
+* *Missing Achievement Report* - A report listing the achievements mapped (or lack thereof) for a given set of locations.
+* *Missing Location Report* - A report listing the locations (or lack thereof) for a given Badge with constituent steps.
+* *Outing and Course* - list the attractions that we want to assure are covered (perhaps this is a criteria on the readiness of a location). 
+
+## Life Cycle
+* This can be verified at the time a Course is assembled.
+* This can be verified at the time an Outing is assembled.
+* Once an Outing has started, a cached copy of the map should be available in memory.
+* Once an Outing has completed (signal from the Guide?), that cached copy can be released.
+
+* There is probably utility in performing a verification across all Attractions (not all Locations which may be in various stages of readiness).
+
+## References
+Wiki Page for Methods of Awarding Badges: http://bikehighways.wikidot.com/methods-of-awarding-badges

--- a/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
@@ -38,9 +38,11 @@ public class BadgeStoreJpa implements BadgeStore {
     private EntityManager entityManager;
 
     @Override
+    // TODO: This won't work - no "DB" joins retrieve the records by User.
     public List<BadgeFeaturesEntity> getAwardedBadgesForUser(Integer userId) {
         LOGGER.debug("Retrieving Badges for User ID {}", userId);
         List<BadgeFeaturesEntity> builderList;
+        // TODO: Retrieve the Badge IDs awarded to a user, and then lookup the set of matching BadgeFeature instances.
         builderList = entityManager.createQuery(
                     "SELECT b FROM badge_display_per_user b WHERE b.userId = :userId"
         )

--- a/src/main/java/com/clueride/domain/badge/event/BadgeEvent.java
+++ b/src/main/java/com/clueride/domain/badge/event/BadgeEvent.java
@@ -36,6 +36,7 @@ public class BadgeEvent {
     private Date timestamp;
     private Principal principal;
     private Integer memberId;
+    private Integer badgeOSId;
     private String methodName;
     private Class methodClass;
     private Object returnValue;
@@ -46,6 +47,7 @@ public class BadgeEvent {
         this.timestamp = builder.getTimestamp();
         this.principal = builder.getPrincipal();
         this.memberId = builder.getMemberId();
+        this.badgeOSId = builder.getBadgeOSId();
         this.methodClass = builder.getMethodClass();
         this.methodName = builder.getMethodName();
         this.returnValue = builder.getReturnValue();
@@ -66,6 +68,10 @@ public class BadgeEvent {
 
     public Integer getMemberId() {
         return memberId;
+    }
+
+    public Integer getBadgeOSId() {
+        return badgeOSId;
     }
 
     public String getMethodName() {
@@ -98,5 +104,4 @@ public class BadgeEvent {
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
     }
-
 }

--- a/src/main/java/com/clueride/domain/badge/event/BadgeEventBuilder.java
+++ b/src/main/java/com/clueride/domain/badge/event/BadgeEventBuilder.java
@@ -60,6 +60,9 @@ public class BadgeEventBuilder {
     @Column(name="member_id")
     private Integer memberId;
 
+    @Column(name = "badgeos_id")
+    private Integer badgeOSId;
+
     @Column(name="method_name")
     private String methodName;
 
@@ -95,6 +98,7 @@ public class BadgeEventBuilder {
                 .withId(badgeEvent.getId())
                 .withPrincipal(badgeEvent.getPrincipal())
                 .withMemberId(badgeEvent.getMemberId())
+                .withBadgeOSId(badgeEvent.getBadgeOSId())
                 .withTimestamp(badgeEvent.getTimestamp())
                 .withMethodClass(badgeEvent.getMethodClass())
                 .withClassName(badgeEvent.getMethodClass().getCanonicalName())
@@ -128,6 +132,15 @@ public class BadgeEventBuilder {
 
     public BadgeEventBuilder withMemberId(Integer memberId) {
         this.memberId = memberId;
+        return this;
+    }
+
+    public Integer getBadgeOSId() {
+        return badgeOSId;
+    }
+
+    public BadgeEventBuilder withBadgeOSId(Integer badgeOSId) {
+        this.badgeOSId = badgeOSId;
         return this;
     }
 

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesEntity.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesEntity.java
@@ -70,7 +70,7 @@ public class BadgeFeaturesEntity {
     @Column(name = "badge_level")
     private String level;
 
-    @Transient
+    @Transient      // Derived from String imageUrlString
     private URL imageUrl;
 
     public BadgeFeaturesEntity() {}

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesService.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesService.java
@@ -30,4 +30,10 @@ public interface BadgeFeaturesService {
      */
     List<BadgeFeatures> getAllBadgeFeatures();
 
+    /**
+     * Retrieve all Badge Features instances for Themed Badges; both open and closed.
+     * @return List of {@link BadgeFeatures} that are Themed.
+     */
+    List<BadgeFeatures> getThemedBadgeFeatures();
+
 }

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesServiceImpl.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesServiceImpl.java
@@ -44,4 +44,14 @@ public class BadgeFeaturesServiceImpl implements BadgeFeaturesService {
         return badgeFeatures;
     }
 
+    @Override
+    public List<BadgeFeatures> getThemedBadgeFeatures() {
+        List<BadgeFeatures> badgeFeatures = new ArrayList<>();
+        List<BadgeFeaturesEntity> entities = badgeFeaturesStore.getThemedBadgeFeatures();
+        for (BadgeFeaturesEntity entity : entities) {
+            badgeFeatures.add(entity.build());
+        }
+        return badgeFeatures;
+    }
+
 }

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStore.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStore.java
@@ -34,4 +34,10 @@ public interface BadgeFeaturesStore {
      */
     List<BadgeFeaturesEntity> getAllBadgeFeatures();
 
+    /**
+     * Retrieves list of Themed Badges; both open and closed.
+     * @return List of Themed {@link BadgeFeaturesEntity}.
+     */
+    List<BadgeFeaturesEntity> getThemedBadgeFeatures();
+
 }

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStoreJpa.java
@@ -46,4 +46,15 @@ public class BadgeFeaturesStoreJpa implements BadgeFeaturesStore {
         return badgeFeaturesEntityList;
     }
 
+    @Override
+    public List<BadgeFeaturesEntity> getThemedBadgeFeatures() {
+        LOGGER.debug("Retrieving list of Themed Badges that can be earned");
+        List<BadgeFeaturesEntity> badgeFeaturesEntityList;
+        badgeFeaturesEntityList = entityManager.createQuery(
+                "SELECT bfe FROM BadgeFeaturesEntity bfe " +
+                        "WHERE bfe.badgeName = 'theme-close-ended' OR bfe.badgeName = 'theme-open-ended'"
+        ).getResultList();
+        return badgeFeaturesEntityList;
+    }
+
 }

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesWebService.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesWebService.java
@@ -42,4 +42,12 @@ public class BadgeFeaturesWebService {
         return badgeFeaturesService.getAllBadgeFeatures();
     }
 
+    @GET
+    @Path("themed")
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<BadgeFeatures> getThemedBadgeFeatures() {
+        return badgeFeaturesService.getThemedBadgeFeatures();
+    }
+
 }

--- a/src/main/java/com/clueride/domain/badge/theme/ThemeEntity.java
+++ b/src/main/java/com/clueride/domain/badge/theme/ThemeEntity.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/28/19.
+ */
+package com.clueride.domain.badge.theme;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Persistable and mutable (but generally read-only) Theme.
+ */
+@Entity
+@Table(name="theme")
+public class ThemeEntity {
+    @Id
+    private int id;
+
+    private String name;
+    private int badgeId;
+
+    @Column(name="open_close")
+    private ThemeType themeType;
+
+    private String url;
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getBadgeId() {
+        return badgeId;
+    }
+
+    public ThemeType getThemeType() {
+        return themeType;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/badge/theme/ThemeStore.java
+++ b/src/main/java/com/clueride/domain/badge/theme/ThemeStore.java
@@ -13,28 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 6/16/19.
+ * Created by jett on 7/28/19.
  */
-package com.clueride.domain.step;
+package com.clueride.domain.badge.theme;
 
 import java.util.List;
 
 /**
- * Defines operations on {@link Step} instances.
+ * Persistence operations for {@link ThemeEntity} instances.
  */
-public interface StepService {
+public interface ThemeStore {
+    /**
+     * Retrieve the list of Themes -- open or closed.
+     * @return List of all ThemeEntity instances.
+     */
+    List<ThemeEntity> getThemes();
 
     /**
-     * Retrieves full list of Steps.
-     * @return Complete List of Steps.
+     * Retrieve the list of Closed Themes.
+     * @return List of all closed ThemeEntity instances.
      */
-    List<Step> getAllSteps();
+    List<ThemeEntity> getClosedThemes();
 
     /**
-     * Retrieves list of Steps for a given Badge.
-     * @param badgeId unique identifier for a Badge.
-     * @return List of the steps just for the given Badge.
+     * Retrieve the list of Open Themes.
+     * @return List of all open ThemeEntity instances.
      */
-    List<Step> getAllStepsForBadge(int badgeId);
+    List<ThemeEntity> getOpenThemes();
 
 }

--- a/src/main/java/com/clueride/domain/badge/theme/ThemeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/theme/ThemeStoreJpa.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/28/19.
+ */
+package com.clueride.domain.badge.theme;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.slf4j.Logger;
+
+/**
+ * JPA implementation of {@link ThemeStore}.
+ */
+public class ThemeStoreJpa implements ThemeStore {
+    @Inject
+    private Logger LOGGER;
+
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public List<ThemeEntity> getThemes() {
+        LOGGER.debug("Retrieving list of All Themes");
+        List<ThemeEntity> themes = entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t"
+        ).getResultList();
+        return themes;
+    }
+
+    @Override
+    public List<ThemeEntity> getClosedThemes() {
+        LOGGER.debug("Retrieving list of Closed Themes");
+        List<ThemeEntity> themes = entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'closed'"
+        ).getResultList();
+        return themes;
+    }
+
+    @Override
+    public List<ThemeEntity> getOpenThemes() {
+        LOGGER.debug("Retrieving list of Open Themes");
+        List<ThemeEntity> themes = entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'open'"
+        ).getResultList();
+        return themes;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/badge/theme/ThemeType.java
+++ b/src/main/java/com/clueride/domain/badge/theme/ThemeType.java
@@ -1,4 +1,4 @@
-/*
+package com.clueride.domain.badge.theme;/*
  * Copyright 2019 Jett Marks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 6/16/19.
+ * Created by jett on 7/28/19.
  */
-package com.clueride.domain.step;
 
-import java.util.List;
+public enum ThemeType {
 
-/**
- * Defines operations on {@link Step} instances.
- */
-public interface StepService {
+    OPEN("open"),
+    CLOSED("closed");
 
-    /**
-     * Retrieves full list of Steps.
-     * @return Complete List of Steps.
-     */
-    List<Step> getAllSteps();
+    private final String label;
 
-    /**
-     * Retrieves list of Steps for a given Badge.
-     * @param badgeId unique identifier for a Badge.
-     * @return List of the steps just for the given Badge.
-     */
-    List<Step> getAllStepsForBadge(int badgeId);
+    ThemeType(String label) {
+        this.label = label;
+    }
 
 }

--- a/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
@@ -198,11 +198,16 @@ public class GameStateServiceImpl implements GameStateService {
      * @param badgeEventName specific Team Event.
      */
     private void recordTeamBadgeEvent(String badgeEventName) {
+        OutingView outingView = clueRideSessionDto.getOutingView();
+        OutingPlusGameState outingPlusGameState = new OutingPlusGameState(
+                gameStateMap.get(outingView.getId()).build(),
+                outingView
+        );
         BadgeEventBuilder badgeEventBuilder = BadgeEventBuilder.builder()
                 .withTimestamp(new Date())
                 .withMethodName(badgeEventName)
                 .withMethodClass(this.getClass())
-                .withReturnValue(clueRideSessionDto.getOutingView());
+                .withReturnValue(outingPlusGameState);
         badgeEventService.sendToTeam(badgeEventBuilder, clueRideSessionDto.getOutingView().getTeamId());
     }
 

--- a/src/main/java/com/clueride/domain/game/OutingPlusGameState.java
+++ b/src/main/java/com/clueride/domain/game/OutingPlusGameState.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/25/19.
+ */
+package com.clueride.domain.game;
+
+import javax.annotation.concurrent.Immutable;
+
+import com.clueride.domain.outing.OutingView;
+
+/**
+ * Record of both the Game State and the OutingView for recording Badge Events.
+ */
+@Immutable
+public class OutingPlusGameState {
+    private final GameState gameState;
+    private final OutingView outingView;
+
+
+    public OutingPlusGameState(
+            GameState gameState,
+            OutingView outingView
+    ) {
+        this.gameState = gameState;
+        this.outingView = outingView;
+    }
+
+    public GameState getGameState() {
+        return gameState;
+    }
+
+    public OutingView getOutingView() {
+        return outingView;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/location/LocationBuilder.java
+++ b/src/main/java/com/clueride/domain/location/LocationBuilder.java
@@ -86,6 +86,9 @@ public class LocationBuilder {
     @JoinColumn(name = "location_type_id")
     private LocationTypeBuilder locationTypeBuilder;
 
+    @Column(name="location_type_id", updatable = false, insertable = false)
+    private Integer locationTypeId;
+
     @Column(name="location_group_id") private Integer locationGroupId;
 
     @Transient
@@ -114,8 +117,6 @@ public class LocationBuilder {
 
     @Transient
     private ReadinessLevel readinessLevel;
-    @Transient
-    private Integer locationTypeId;
 
     public LocationBuilder() {}
 

--- a/src/main/java/com/clueride/domain/location/LocationService.java
+++ b/src/main/java/com/clueride/domain/location/LocationService.java
@@ -105,4 +105,10 @@ public interface LocationService {
      */
     List<LocLink> getLocationLinksByLocation(Integer locationId);
 
+    /**
+     * Retrieves List of Locations expected to be part of a Theme.
+     * @return List of Themed Locations.
+     */
+    List<Location> getThemeLocations();
+
 }

--- a/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
@@ -224,6 +224,20 @@ public class LocationServiceImpl implements LocationService {
         return null;
     }
 
+    @Override
+    public List<Location> getThemeLocations() {
+        LOGGER.info("Retrieving Themed Locations");
+        List<Location> locations = new ArrayList<>();
+
+        for (LocationBuilder builder : locationStore.getThemedLocationBuilders()) {
+            /* For these Location instances, what we certainly need is the IDs and the Type.
+             * Unclear if we need the readiness level at this time.
+             */
+            locations.add(builder.build());
+        }
+        return locations;
+    }
+
     // TODO: SVR-36 Tidy LocType (maybe)
     private void fillAndGradeLocation(LocationBuilder builder) {
         /* Assemble the derived transient fields. */

--- a/src/main/java/com/clueride/domain/location/LocationStore.java
+++ b/src/main/java/com/clueride/domain/location/LocationStore.java
@@ -55,4 +55,10 @@ public interface LocationStore {
      */
     void delete(LocationBuilder location);
 
+    /**
+     * Retrieves list of Themed Location Builders.
+     * @return Iterable over themed LocationBuilders
+     */
+    Iterable<? extends LocationBuilder> getThemedLocationBuilders();
+
 }

--- a/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
@@ -103,4 +103,17 @@ public class LocationStoreJpa implements LocationStore {
         }
     }
 
+    @Override
+    public Iterable<? extends LocationBuilder> getThemedLocationBuilders() {
+        Collection<LocationBuilder> builderCollection = new ArrayList<>();
+        List<LocationBuilder> locationList = entityManager.createQuery(
+                "SELECT l FROM location l" +
+                        " WHERE l.locationTypeId IN (" +
+                        "SELECT lt.id from location_type lt WHERE lt.themeId IN (" +
+                        "SELECT t.id from ThemeEntity t) )"
+        ).getResultList();
+        builderCollection.addAll(locationList);
+        return builderCollection;
+    }
+
 }

--- a/src/main/java/com/clueride/domain/location/LocationWebService.java
+++ b/src/main/java/com/clueride/domain/location/LocationWebService.java
@@ -174,4 +174,11 @@ public class LocationWebService {
         return locationService.linkMainLocLink(locationId, locLinkId);
     }
 
+    @GET
+    @Path("themed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Location> getThemedLocations() {
+        return locationService.getThemeLocations();
+    }
+
 }

--- a/src/main/java/com/clueride/domain/location/loctype/LocationType.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationType.java
@@ -35,6 +35,7 @@ public class LocationType {
     private String description;
     private String icon;
     private Category category;
+    private Integer themeId;
 
     // TODO: Temporary constructor in service of JSON
     public LocationType() {}
@@ -47,6 +48,7 @@ public class LocationType {
         if (builder.getCategory() != null) {
             this.category = builder.getCategory().build();
         }
+        this.themeId = builder.getThemeId();
     }
 
     public int getId() {
@@ -67,6 +69,10 @@ public class LocationType {
 
     public Category getCategory() {
         return category;
+    }
+
+    public Integer getThemeId() {
+        return themeId;
     }
 
     @Override

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeBuilder.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeBuilder.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.location.loctype;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -48,6 +49,9 @@ public final class LocationTypeBuilder {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "category_id")
     private CategoryEntity categoryEntity;
+
+    @Column(name = "theme_id")
+    private Integer themeId;
 
     /**
      * Generate instance from Builder's values.
@@ -120,6 +124,10 @@ public final class LocationTypeBuilder {
     public LocationTypeBuilder withCategory(CategoryEntity categoryEntity) {
         this.categoryEntity = categoryEntity;
         return this;
+    }
+
+    public Integer getThemeId() {
+        return themeId;
     }
 
 }

--- a/src/main/java/com/clueride/domain/step/StepServiceImpl.java
+++ b/src/main/java/com/clueride/domain/step/StepServiceImpl.java
@@ -39,4 +39,13 @@ public class StepServiceImpl implements StepService {
         return steps;
     }
 
+    @Override
+    public List<Step> getAllStepsForBadge(int badgeId) {
+        List<Step> steps = new ArrayList<>();
+        for (StepEntity entity : stepStore.getStepsForBadge(badgeId)) {
+            steps.add(entity.build());
+        }
+        return steps;
+    }
+
 }

--- a/src/main/java/com/clueride/domain/step/StepStore.java
+++ b/src/main/java/com/clueride/domain/step/StepStore.java
@@ -33,4 +33,11 @@ public interface StepStore {
      */
     List<StepEntity> getAllSteps();
 
+    /**
+     * Retrieve instances of Step for the given Badge.
+     * @param badgeId unique identifier for a given Badge.
+     * @return List of Steps to complete before Badge can be earned.
+     */
+    Iterable<? extends StepEntity> getStepsForBadge(int badgeId);
+
 }

--- a/src/main/java/com/clueride/domain/step/StepWebService.java
+++ b/src/main/java/com/clueride/domain/step/StepWebService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -40,6 +41,14 @@ public class StepWebService {
     @Produces(MediaType.APPLICATION_JSON)
     public List<Step> getAllSteps() {
         return stepService.getAllSteps();
+    }
+
+    @GET
+    @Secured
+    @Path("badge/{badgeId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Step> getStepsForBadge(@PathParam("badgeId") Integer badgeId) {
+        return stepService.getAllStepsForBadge(badgeId);
     }
 
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -26,7 +26,6 @@
       <jta-data-source>java:/DS/PostgreSQL</jta-data-source>
       <properties>
          <!-- Properties for Hibernate -->
-         <property name="hibernate.hbm2ddl.auto" value="update" />
          <property name="hibernate.show_sql" value="false" />
          <property name="hibernate.dialect" value="org.hibernate.spatial.dialect.postgis.PostgisPG9Dialect" />
       </properties>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -14,5 +14,5 @@ log4j.appender.APP_LOG.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p
 
 
 # Logging config for HttpClient (see http://hc.apache.org/httpcomponents-client-4.4.x/logging.html)
-log4j.logger.org.apache.http=DEBUG, APP_LOG
+# log4j.logger.org.apache.http=DEBUG, APP_LOG
 log4j.logger.org.apache.http.wire=ERROR, APP_LOG


### PR DESCRIPTION
- Adds mapping between location/attractions and the matching achievement.
- Adds ArrivalStepsMap service to provide that map. (Others will follow)
- Adds Service to perform the awards (could hold all of the types).
- Amends the BadgeEvent to carry BadgeOS ID as well as Clue Ride internal Member ID
(We might expect members without Word Press accounts.)
- Themes are added to help distinguish the types of awards; includes tie to Location Type.
- Expanded the Badge Event's "payload" to include both the outing and the game state.
- Location Type is persisted instead of being a transient property.
- For the purposes of checking that we have a complete set of Locations for a given theme, there is a Location Service call that retrieves all locations by Theme.
- Refactors Steps so we can retrieve the list of steps for a given badge.

Non functional:
- turns off the hbm2ddl update config in the `persistence.xml`
- Adds properties for the HTTP client code for logging.