### PR TITLE
SVR-81 Trouble saving updated Attractions - Main Link

### DIFF
--- a/src/main/java/com/clueride/domain/location/LocationEntity.java
+++ b/src/main/java/com/clueride/domain/location/LocationEntity.java
@@ -43,7 +43,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 
 import com.clueride.domain.image.ImageLinkEntity;
 import com.clueride.domain.location.latlon.LatLonEntity;
-import com.clueride.domain.location.loclink.LocLink;
 import com.clueride.domain.location.loclink.LocLinkEntity;
 import com.clueride.domain.location.loctype.LocationType;
 import com.clueride.domain.location.loctype.LocationTypeEntity;
@@ -360,11 +359,9 @@ public class LocationEntity {
         return this;
     }
 
-    public LocationEntity withLocLink(LocLink locLink) {
+    public LocationEntity withLocLink(LocLinkEntity locLinkEntity) {
         // TODO: This is SVR-36 too
-        this.mainLink = LocLinkEntity.builder()
-                .withId(locLink.getId())
-                .withLink(locLink.getLink());
+        this.mainLink = locLinkEntity;
         return this;
     }
 

--- a/src/main/java/com/clueride/domain/location/LocationService.java
+++ b/src/main/java/com/clueride/domain/location/LocationService.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.location;
 
+import java.net.MalformedURLException;
 import java.util.List;
 
 import com.clueride.domain.course.Course;
@@ -38,7 +39,7 @@ public interface LocationService {
      * @param locationEntity instance with updated properties.
      * @return the updated and built Location.
      */
-    Location updateLocation(LocationEntity locationEntity);
+    Location updateLocation(LocationEntity locationEntity) throws MalformedURLException;
 
     /**
      * Given coordinates for a new location, create an instance with
@@ -81,14 +82,14 @@ public interface LocationService {
      * @param imageId unique identifier for an existing Image.
      * @return the updated Location instance.
      */
-    Location linkFeaturedImage(Integer locationId, Integer imageId);
+    Location linkFeaturedImage(Integer locationId, Integer imageId) throws MalformedURLException;
 
     /**
      * Drops the link between this Location and the Featured Image.
      * @param locationId unique Identifier for the Location whose featured image we want to unlink.
      * @return The updated and re-evaluated Location.
      */
-    Location unlinkFeaturedImage(Integer locationId);
+    Location unlinkFeaturedImage(Integer locationId) throws MalformedURLException;
 
     /**
      * Connects an established Location with an established LocLink record.

--- a/src/main/java/com/clueride/domain/location/LocationWebService.java
+++ b/src/main/java/com/clueride/domain/location/LocationWebService.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.location;
 
+import java.net.MalformedURLException;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -80,7 +81,7 @@ public class LocationWebService {
     @Secured
     @Path("update")
     @Produces(MediaType.APPLICATION_JSON)
-    public Location updateLocation(LocationEntity locationEntity) {
+    public Location updateLocation(LocationEntity locationEntity) throws MalformedURLException {
         return locationService.updateLocation(locationEntity);
     }
 
@@ -150,7 +151,7 @@ public class LocationWebService {
     public Location linkFeaturedImage(
             @PathParam("locId") Integer locationId,
             @PathParam("imageId") Integer imageId
-    ) {
+    ) throws MalformedURLException {
         return locationService.linkFeaturedImage(locationId, imageId);
     }
 
@@ -158,7 +159,7 @@ public class LocationWebService {
     @Secured
     @Path("featured/")
     @Produces(MediaType.APPLICATION_JSON)
-    public Location unlinkFeaturedImage(@QueryParam("id") Integer locationId) {
+    public Location unlinkFeaturedImage(@QueryParam("id") Integer locationId) throws MalformedURLException {
         return locationService.unlinkFeaturedImage(locationId);
     }
 

--- a/src/main/java/com/clueride/domain/location/loclink/LocLinkService.java
+++ b/src/main/java/com/clueride/domain/location/loclink/LocLinkService.java
@@ -19,6 +19,8 @@ package com.clueride.domain.location.loclink;
 
 import java.net.MalformedURLException;
 
+import com.clueride.domain.location.LocationEntity;
+
 /**
  * Defines operations on Location Links.
  */
@@ -28,16 +30,25 @@ public interface LocLinkService {
      * Given a URL passed within a LocLinkEntity instance, create a record in the database for this URL.
      * @param locLinkEntity instance containing the URL.
      * @return Fully-populated LocLink instance with the newly created record ID.
-     * @throws java.net.MalformedURLException if the string URL isn't properly formed.
+     * @throws MalformedURLException if the string URL isn't properly formed.
      */
-    LocLink createNewLocationLink(LocLinkEntity locLinkEntity) throws MalformedURLException;
+    LocLinkEntity createNewLocationLink(LocLinkEntity locLinkEntity) throws MalformedURLException;
 
     /**
      * Retrieves an existing LocLink if found, or creates a new one if not found.
      *
      * @param locLinkText text of the URL to be obtained.
      * @return Matching LocLink or a new instance if not found.
+     * @throws MalformedURLException if the string URL isn't properly formed.
      */
-    LocLink getLocLinkByUrl(String locLinkText) throws MalformedURLException;
+    LocLinkEntity getLocLinkByUrl(String locLinkText) throws MalformedURLException;
 
+    /**
+     * Performs checks and validates the link text before creating an appropriate
+     * instance of {@link LocLinkEntity} for adding to a {@link LocationEntity}.
+     * @param locLinkEntity instance to be checked; supplies the link text.
+     * @return Either null, or a persisted instance of a Link.
+     * @throws MalformedURLException if the string URL isn't properly formed.
+     */
+    LocLinkEntity validateAndPrepareFromUserInput(LocLinkEntity locLinkEntity) throws MalformedURLException;
 }

--- a/src/main/java/com/clueride/domain/location/loclink/LocLinkServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/loclink/LocLinkServiceImpl.java
@@ -22,6 +22,8 @@ import java.net.URL;
 
 import javax.inject.Inject;
 
+import com.google.common.base.Strings;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -33,20 +35,22 @@ public class LocLinkServiceImpl implements LocLinkService {
     private LocLinkStore locLinkStore;
 
     @Override
-    public LocLink createNewLocationLink(LocLinkEntity locLinkEntity) throws MalformedURLException {
+    public LocLinkEntity createNewLocationLink(LocLinkEntity locLinkEntity) throws MalformedURLException {
         String link = requireNonNull(locLinkEntity.getLink());
-        URL url = new URL(link);
+        /* Try creating a URL from the link to make sure it is valid. */
+        new URL(link);
         locLinkStore.addNew(locLinkEntity);
-        return locLinkEntity.build();
+        return locLinkEntity;
     }
 
     @Override
-    public LocLink getLocLinkByUrl(String locLinkText) throws MalformedURLException {
+    public LocLinkEntity getLocLinkByUrl(String locLinkText) throws MalformedURLException {
         requireNonNull(locLinkText);
-        URL url = new URL(locLinkText);
+        /* Try creating a URL from the link to make sure it is valid. */
+        new URL(locLinkText);
         LocLinkEntity locLinkEntity = locLinkStore.findByUrl(locLinkText);
         if (locLinkEntity != null) {
-            return locLinkEntity.build();
+            return locLinkEntity;
         } else {
             return createNewLocationLink(
                     new LocLinkEntity().withLink(locLinkText)
@@ -54,4 +58,19 @@ public class LocLinkServiceImpl implements LocLinkService {
         }
 
     }
+
+    @Override
+    public LocLinkEntity validateAndPrepareFromUserInput(LocLinkEntity locLinkEntity) throws MalformedURLException {
+        if (Strings.isNullOrEmpty(locLinkEntity.getLink())) {
+            /* No attempt to provide a valid link. */
+            return null;
+        }
+        String link = locLinkEntity.getLink();
+
+        /* Check the value. */
+        new URL(link);
+
+        return getLocLinkByUrl(link);
+    }
+
 }

--- a/src/main/java/com/clueride/domain/location/loclink/LocLinkWebService.java
+++ b/src/main/java/com/clueride/domain/location/loclink/LocLinkWebService.java
@@ -42,7 +42,7 @@ public class LocLinkWebService {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public LocLink createNewLocationLink(LocLinkEntity locLinkEntity) throws MalformedURLException {
-        return locLinkService.createNewLocationLink(locLinkEntity);
+        return locLinkService.createNewLocationLink(locLinkEntity).build();
     }
 
 }


### PR DESCRIPTION
- Uses Loc Link *Entity* which has been persisted instead of Entity created from
another instance.
- Switches the Loc Type ID to use the one from the instance instead of
the flattened value.
- Now throwing any Malformed URLs back to the client (see CI-56).