### PR TITLE
SVR-83 Add Exception Mapper handling

### DIFF
--- a/src/main/java/com/clueride/DefaultExceptionMapper.java
+++ b/src/main/java/com/clueride/DefaultExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 1/1/20.
+ */
+package com.clueride;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+
+/**
+ * Handles uncaught exceptions by wrapping them in a 500 Response.
+ */
+@Provider
+public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
+
+    public Response toResponse(Throwable e) {
+        if (e instanceof DefaultOptionsMethodException) {
+            return null;
+        }
+
+        return Response
+                .status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(e.toString())
+                .build();
+    }
+
+}


### PR DESCRIPTION
- Adds default handler for all `Throwable` (with the exception of an
internal DefaultOptionsMethodException -- see SVR-84).