### PR TITLE
SVR-36 Tidy up Location Type for the Location

### DIFF
--- a/src/main/java/com/clueride/DefaultExceptionMapper.java
+++ b/src/main/java/com/clueride/DefaultExceptionMapper.java
@@ -17,11 +17,13 @@
  */
 package com.clueride;
 
+import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+import org.slf4j.Logger;
 
 /**
  * Handles uncaught exceptions by wrapping them in a 500 Response.
@@ -29,11 +31,16 @@ import org.jboss.resteasy.spi.DefaultOptionsMethodException;
 @Provider
 public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
 
+    @Inject
+    private Logger LOGGER;
+
     public Response toResponse(Throwable e) {
         /* TODO: SVR-84 improve response to this exception. */
         if (e instanceof DefaultOptionsMethodException) {
             return null;
         }
+
+        LOGGER.error(e.getMessage(), e);
 
         return Response
                 .status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/clueride/domain/location/Location.java
+++ b/src/main/java/com/clueride/domain/location/Location.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import com.clueride.domain.image.ImageLink;
 import com.clueride.domain.location.latlon.LatLonEntity;
 import com.clueride.domain.location.loclink.LocLink;
-import com.clueride.domain.location.loctype.LocationType;
 import com.clueride.domain.puzzle.PuzzleEntity;
 
 /**
@@ -46,7 +45,7 @@ public class Location {
     private final int nodeId;
     private final String name;
     private final String description;
-    private final LocationType locationType;
+    private final Integer locationTypeId;
     private final ImageLink featuredImage;
     private final LocLink mainLink;
     private final Integer googlePlaceId;
@@ -60,7 +59,7 @@ public class Location {
 
     /**
      * Constructor accepting Builder instance.
-     * @param builder instance carrying mutable Location.
+     * @param builder {@link LocationEntity} instance carrying mutable Location.
      */
     public Location(LocationEntity builder) {
         id = builder.getId();
@@ -71,7 +70,7 @@ public class Location {
         // If any of these are missing, we're at the Draft level
         name = builder.getName();
         description = builder.getDescription();
-        locationType = builder.getLocationType();
+        locationTypeId = builder.getLocationTypeId();
 
         /* OK for Location to be missing Featured Image. */
         if (builder.getFeaturedImage() != null) {
@@ -127,15 +126,7 @@ public class Location {
      * @return Enumeration of the type of Location.
      */
     public Integer getLocationTypeId() {
-        return (locationType == null ? 0 : locationType.getId());
-    }
-
-    public String getLocationTypeName() {
-        return (locationType == null ? "none" : locationType.getName());
-    }
-
-    public LocationType getLocationType() {
-        return locationType;
+        return (locationTypeId);
     }
 
     /**

--- a/src/main/java/com/clueride/domain/location/LocationEntity.java
+++ b/src/main/java/com/clueride/domain/location/LocationEntity.java
@@ -69,6 +69,7 @@ public class LocationEntity {
     @SequenceGenerator(name="location_pk_sequence",sequenceName="location_id_seq", allocationSize=1)
     private Integer id;
 
+    /* Human readable characteristics. */
     private String name;
     private String description;
 
@@ -81,10 +82,6 @@ public class LocationEntity {
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name= "main_link_id")
     private LocLinkEntity mainLink;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "location_type_id")
-    private LocationTypeEntity locationTypeEntity;
 
     @Column(name="location_type_id", updatable = false, insertable = false)
     private Integer locationTypeId;
@@ -129,7 +126,7 @@ public class LocationEntity {
                 .withId(location.getId())
                 .withName(location.getName())
                 .withDescription(location.getDescription())
-                .withLocationType(location.getLocationType())
+                .withLocationTypeId(location.getLocationTypeId())
                 .withNodeId(location.getNodeId())
                 .withLatLon(location.getLatLon())
                 .withFeaturedImage(ImageLinkEntity.from(location.getFeaturedImage()))
@@ -150,12 +147,6 @@ public class LocationEntity {
                                 + featuredImage.getUrl()
                 );
             }
-        }
-
-        if (locationTypeEntity == null) {
-            throw new IllegalStateException("Location Type cannot be null");
-        } else {
-            locationType = locationTypeEntity.build();
         }
         return new Location(this);
     }
@@ -199,10 +190,9 @@ public class LocationEntity {
     }
 
     /**
-     * This is generally inbound from clients. Service is responsible for
-     * taking this value, looking up the LocationType via its service, and
-     * then populating this LocationEntity instance with that LocationType
-     * instance.
+     * Service is responsible for taking this value and looking up the
+     * LocationType(Entity) via its service.
+     *
      * @param locationTypeId chosen from a list of possible Location Types.
      * @return this.
      */
@@ -210,6 +200,8 @@ public class LocationEntity {
         this.locationTypeId = locationTypeId;
         return this;
     }
+
+    /* TODO CI-152: Flagging Attraction; expect to play with ReadinessLevel. */
 
     public Integer getLocationTypeId() {
         return locationTypeId;
@@ -249,6 +241,11 @@ public class LocationEntity {
         return this;
     }
 
+    public LocationEntity withReadinessLevel(ReadinessLevel readinessLevel) {
+        this.readinessLevel = readinessLevel;
+        return this;
+    }
+
     public Integer getNodeId() {
         return nodeId;
     }
@@ -257,6 +254,7 @@ public class LocationEntity {
         this.nodeId = nodeId;
         return this;
     }
+    /* FUTURE */
 
     public Map<String, Optional<Double>> getTagScores() {
         return tagScores;
@@ -305,8 +303,8 @@ public class LocationEntity {
         }
         return this;
     }
-
     /* Image Methods */
+
     public ImageLinkEntity getFeaturedImage() {
         return featuredImage;
     }
@@ -354,22 +352,24 @@ public class LocationEntity {
     }
 
     public LocationEntity withMainLink(LocLinkEntity locLink) {
-        // TODO: This is SVR-36 too
+        // TODO: SVR-94
         this.mainLink = locLink;
         return this;
     }
 
     public LocationEntity withLocLink(LocLinkEntity locLinkEntity) {
-        // TODO: This is SVR-36 too
+        // TODO: SVR-94
         this.mainLink = locLinkEntity;
         return this;
     }
 
     public List<PuzzleEntity> getPuzzleEntities() {
+        // TODO SVR-94
         return puzzleEntities;
     }
 
     public LocationEntity withPuzzleBuilders(List<PuzzleEntity> puzzleEntities) {
+        // TODO SVR-94
         this.puzzleEntities = puzzleEntities;
         return this;
     }
@@ -377,31 +377,11 @@ public class LocationEntity {
     public Integer getGooglePlaceId() {
         return googlePlaceId;
     }
+    /* FUTURE */
 
     public LocationEntity withGooglePlaceId(Integer googlePlaceId) {
         this.googlePlaceId = googlePlaceId;
         return this;
-    }
-
-    public ReadinessLevel getReadinessLevel() {
-        return readinessLevel;
-    }
-
-    /**
-     * Accepts a partial set of information -- generally posted from REST API -- and updates this copy with the
-     * new fields.
-     * @param locationEntity instance with the new info.
-     */
-    public void updateFrom(LocationEntity locationEntity) {
-        this
-                .withName(locationEntity.name)
-                .withId(locationEntity.id)
-                .withDescription(locationEntity.description)
-                .withNodeId(locationEntity.nodeId)
-                // TODO: SVR-36
-//                .withLocationTypeId(locationEntity.locationTypeId)
-                .withLocationGroupId(locationEntity.locationGroupId)
-        ;
     }
 
 }

--- a/src/main/java/com/clueride/domain/place/ScoredLocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/place/ScoredLocationServiceImpl.java
@@ -47,7 +47,7 @@ public class ScoredLocationServiceImpl implements ScoredLocationService {
         if (isNullOrEmpty(location.getName())
                 && isNullOrEmpty(location.getDescription())
                 && location.getFeaturedImage() == null
-                && location.getLocationTypeEntity().getId() == 0
+                && location.getLocationTypeId() == 0
                 ) {
             return ReadinessLevel.NODE;
         }
@@ -56,7 +56,7 @@ public class ScoredLocationServiceImpl implements ScoredLocationService {
         if (isNullOrEmpty(location.getName())
                 || isNullOrEmpty(location.getDescription())
                 || location.getFeaturedImage() == null
-                || location.getLocationTypeEntity().getId() == 0
+                || location.getLocationTypeId() == 0
                 ) {
             return ReadinessLevel.DRAFT;
         }


### PR DESCRIPTION
- Removes LocationTypeEntity from LocationEntity and replaces it with LocationTypeId
which is the value we keep in the database table.

Also adds logging of stack trace when we encounter an uncaught exception
that we return to the REST clients.