### PR TITLE
SVR-96 Back-end Support (and API) for Managing Incomplete Attractions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,11 +291,6 @@
             <version>3.0.0</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-osgi-bundle</artifactId>
-            <version>2.0.0.Alpha3</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>2.8.4</version>
@@ -303,7 +298,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.9.2,)</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -406,12 +401,6 @@
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
             <type>pom</type>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se</artifactId>
-            <version>2.4.8.Final</version>
-            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/clueride/domain/attraction/Attraction.java
+++ b/src/main/java/com/clueride/domain/attraction/Attraction.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2020 Jett Marks
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created May 5, 2020
+ */
+package com.clueride.domain.attraction;
+
+import com.clueride.domain.image.ImageLink;
+import com.clueride.domain.location.LocationEntity;
+import com.clueride.domain.location.ReadinessLevel;
+import com.clueride.domain.location.latlon.LatLonEntity;
+import com.clueride.domain.location.loclink.LocLink;
+import com.clueride.domain.puzzle.PuzzleEntity;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Holds the data for a Location presented both to the Game Player as well as Editors.
+ *
+ * {@link LocationEntity} holds mutable instances.
+ *
+ * @author jett
+ */
+@Immutable
+public class Attraction {
+    private final int id;
+    private final int nodeId;
+    private final String name;
+    private final String description;
+    private final Integer locationTypeId;
+    private final ImageLink featuredImage;
+    private final LocLink mainLink;
+    private final Integer googlePlaceId;
+    private final LatLonEntity latLon;
+    private final ReadinessLevel readinessLevel;
+    private List<PuzzleEntity> puzzleEntities;
+    private final Integer locationGroupId;
+    private final String establishment;
+    private final Integer establishmentId;
+    private final Map<String, Optional<Double>> tagScores;
+
+    /**
+     * Constructor accepting Entity instance.
+     *
+     * @param entity {@link AttractionEntity} instance carrying mutable Attraction.
+     */
+    public Attraction(AttractionEntity entity) {
+        id = entity.getId();
+        nodeId = entity.getNodeId();
+        latLon = entity.getLatLonEntity();
+        readinessLevel = entity.getReadinessLevel();
+
+        // If any of these are missing, we're at the Draft level
+        name = entity.getName();
+        description = entity.getDescription();
+        locationTypeId = entity.getLocationTypeId();
+
+        /* OK for Location to be missing Featured Image. */
+        if (entity.getFeaturedImage() != null) {
+            featuredImage = entity.getFeaturedImage().build();
+        } else {
+            featuredImage = null;
+        }
+
+        /* OK for Location to be missing its Main Link. */
+        if (entity.getMainLink().isPresent()) {
+            mainLink = entity.getMainLink().get().build();
+        } else {
+            mainLink = null;
+        }
+
+        // Featured Level requires the following
+        googlePlaceId = entity.getGooglePlaceId();
+
+        // Possibly empty list
+        tagScores = entity.getTagScores();
+
+        // Optional values
+        locationGroupId = entity.getLocationGroupId();
+        establishmentId = entity.getEstablishmentId();
+        establishment = entity.getEstablishment();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Human readable name for this location.
+     * Shows up in headings for the Location, Lists of Locations, and as pop-ups on the map.
+     * @return String representing human-readable name of Location.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Textual description of this Location.
+     * Describes why this location is interesting.
+     * @return String representing a description of this Location.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Enumeration of the type of Location.
+     * Plays a role in helping select locations and categorizes them.
+     * @return Enumeration of the type of Location.
+     */
+    public Integer getLocationTypeId() {
+        return (locationTypeId);
+    }
+
+    /**
+     * Link over to the geographical representation of this Location.
+     * @return ID of the LatLonEntity associated with this location for placement on a map.
+     */
+    public Integer getNodeId() {
+        return nodeId;
+    }
+
+    public LatLonEntity getLatLon() {
+        return latLon;
+    }
+
+    public Map<String, Optional<Double>> getTagScores() {
+        return tagScores;
+    }
+
+    /**
+     * This method returns null for an empty Location Group to
+     * accommodate the JSON writer, but not sure this is what
+     * we'll continue to want.
+     * @return Integer or null if not present.
+     */
+    public Integer getLocationGroupId() {
+        if(locationGroupId != null) {
+            return locationGroupId;
+        } else {
+            return null;
+        }
+    }
+
+    public Integer getEstablishment() {
+        return establishmentId;
+    }
+
+    public ImageLink getFeaturedImage() {
+        return featuredImage;
+    }
+
+    public LocLink getMainLink() {
+        return mainLink;
+    }
+
+    /**
+     * Determines progress against criteria described here: http://bikehighways.wikidot.com/clueride-location-details
+     * @return Readiness level based on completeness of the fields for this object.
+     */
+    public ReadinessLevel getReadinessLevel() {
+        return readinessLevel;
+    }
+
+    public Integer getGooglePlaceId() {
+        return googlePlaceId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionEntity.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionEntity.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2019 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 5/5/20.
+ */
+package com.clueride.domain.attraction;
+
+import com.clueride.domain.image.ImageLinkEntity;
+import com.clueride.domain.location.ReadinessLevel;
+import com.clueride.domain.location.latlon.LatLonEntity;
+import com.clueride.domain.location.loclink.LocLinkEntity;
+import com.clueride.domain.puzzle.PuzzleEntity;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import javax.persistence.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Knows how to assemble the parts of a Attraction.
+ *
+ * In this incarnation, the target client is the Player application.
+ * We may get mileage out of this for the Ranger, but that's
+ * not the focus at this date (Jan 2019).
+ *
+ * OK, on Feb 5 2019, we're looking at whether this will serve the
+ * Ranger app ;-). Looks like the Puzzle Builders are considered to
+ * determine the ReadinessLevel of the Attraction. I think we can consult
+ * the Puzzle Service to find what we need.
+ */
+@Entity
+@Table(name="location")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AttractionEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="location_pk_sequence")
+    @SequenceGenerator(name="location_pk_sequence",sequenceName="location_id_seq", allocationSize=1)
+    private Integer id;
+
+    /* Human readable characteristics. */
+    private String name;
+    private String description;
+
+    @Column(name="node_id") private Integer nodeId;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name="featured_image_id")
+    private ImageLinkEntity featuredImage;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name= "main_link_id")
+    private LocLinkEntity mainLink;
+
+    @Column(name="location_type_id", updatable = false, insertable = false)
+    private Integer locationTypeId;
+
+    @Column(name="location_group_id") private Integer locationGroupId;
+
+    @Transient
+    private LatLonEntity latLonEntity;
+    @Transient
+    private URL featuredImageUrl;
+    @Transient
+    private Integer featuredImageId;
+    @Transient
+    private List<PuzzleEntity> puzzleEntities;
+    @Transient
+    private Integer googlePlaceId;
+
+    @Transient
+    private Integer establishmentId;
+
+    @Transient
+    private Map<String, Optional<Double>> tagScores = new HashMap<>();
+
+    @Transient
+    private String establishment;
+
+    @Transient
+    private ReadinessLevel readinessLevel;
+
+    public AttractionEntity() {}
+
+    public static com.clueride.domain.attraction.AttractionEntity builder() {
+        return new com.clueride.domain.attraction.AttractionEntity();
+    }
+
+    public static AttractionEntity from(Attraction location) {
+        return builder()
+                .withId(location.getId())
+                .withName(location.getName())
+                .withDescription(location.getDescription())
+                .withLocationTypeId(location.getLocationTypeId())
+                .withNodeId(location.getNodeId())
+                .withLatLon(location.getLatLon())
+                .withFeaturedImage(ImageLinkEntity.from(location.getFeaturedImage()))
+                .withEstablishmentId(location.getEstablishment())
+                .withTagScores(location.getTagScores())
+                ;
+    }
+
+    public Attraction build() {
+        /* Convert String to URL */
+        if (featuredImage != null) {
+            try {
+                featuredImageId = featuredImage.getId();
+                featuredImageUrl = new URL(featuredImage.getUrl());
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(
+                        "Got a bad URL in the Image table: "
+                                + featuredImage.getUrl()
+                );
+            }
+        }
+        return new Attraction(this);
+    }
+
+    public AttractionEntity withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * If the value has been set (by reading from the AttractionStore), use that
+     * value, otherwise, we're creating a new instance the and idProvider should
+     * give us the next available value.
+     * @return Unique ID for this instance of Attraction.
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AttractionEntity withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public AttractionEntity withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /* Location Type ID. */
+    public Integer getLocationTypeId() {
+        return locationTypeId;
+    }
+
+    /**
+     * Service is responsible for taking this value and looking up the
+     * LocationType(Entity) via its service.
+     *
+     * @param locationTypeId chosen from a list of possible Location Types.
+     * @return this.
+     */
+    public AttractionEntity withLocationTypeId(Integer locationTypeId) {
+        this.locationTypeId = locationTypeId;
+        return this;
+    }
+
+    /* TODO CI-152: Flagging Attraction; expect to play with ReadinessLevel. */
+
+    public ReadinessLevel getReadinessLevel() {
+        return readinessLevel;
+    }
+
+    public AttractionEntity withReadinessLevel(ReadinessLevel readinessLevel) {
+        this.readinessLevel = readinessLevel;
+        return this;
+    }
+
+    public Integer getNodeId() {
+        return nodeId;
+    }
+
+    public AttractionEntity withNodeId(Integer nodeId) {
+        this.nodeId = nodeId;
+        return this;
+    }
+    /* FUTURE */
+
+    public Map<String, Optional<Double>> getTagScores() {
+        return tagScores;
+    }
+
+    public AttractionEntity withTagScores(Map<String, Optional<Double>> tagScores) {
+        this.tagScores = tagScores;
+        return this;
+    }
+
+    public Integer getLocationGroupId() {
+        return locationGroupId;
+    }
+
+    public AttractionEntity withLocationGroupId(Integer locationGroupId) {
+        this.locationGroupId = locationGroupId;
+        return this;
+    }
+
+    public Integer getEstablishmentId() {
+        return establishmentId;
+    }
+
+    public AttractionEntity withEstablishmentId(Integer establishmentId) {
+        this.establishmentId = establishmentId;
+        return this;
+    }
+
+    public String getEstablishment() {
+        return establishment;
+    }
+
+    public AttractionEntity withEstablishment(String establishment) {
+        this.establishment = establishment;
+        return this;
+    }
+
+    public LatLonEntity getLatLonEntity() {
+        return latLonEntity;
+    }
+
+    public AttractionEntity withLatLon(LatLonEntity latLonEntity) {
+        this.latLonEntity = latLonEntity;
+        if (latLonEntity != null) {
+            this.nodeId = latLonEntity.getId();
+        }
+        return this;
+    }
+    /* Image Methods */
+
+    public ImageLinkEntity getFeaturedImage() {
+        return featuredImage;
+    }
+
+    public AttractionEntity withFeaturedImage(ImageLinkEntity featuredImage) {
+        this.featuredImage = featuredImage;
+        this.featuredImageId = featuredImage.getId();
+        try {
+            this.featuredImageUrl = new URL(featuredImage.getUrl());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Bad URL: " + featuredImage.getUrl(), e);
+        }
+        return this;
+    }
+
+    public AttractionEntity clearFeaturedImage() {
+        this.featuredImageId = null;
+        this.featuredImage = null;
+        return this;
+    }
+
+    public boolean hasNoFeaturedImage() {
+        return featuredImageId == null;
+    }
+
+    public Integer getFeaturedImageId() {
+        return featuredImageId;
+    }
+
+    public AttractionEntity withFeaturedImageId(int imageId) {
+        this.featuredImageId = imageId;
+        return this;
+    }
+
+    public AttractionEntity withFeaturedImageUrl(URL featuredImageUrl) {
+        this.featuredImageUrl = featuredImageUrl;
+        return this;
+    }
+
+    /* End of Image Methods */
+
+
+    public Optional<LocLinkEntity> getMainLink() {
+        return Optional.ofNullable(this.mainLink);
+    }
+
+    public AttractionEntity withMainLink(LocLinkEntity locLink) {
+        // TODO: SVR-94
+        this.mainLink = locLink;
+        return this;
+    }
+
+    public AttractionEntity withLocLink(LocLinkEntity locLinkEntity) {
+        // TODO: SVR-94
+        this.mainLink = locLinkEntity;
+        return this;
+    }
+
+    public List<PuzzleEntity> getPuzzleEntities() {
+        // TODO SVR-94
+        return puzzleEntities;
+    }
+
+    public AttractionEntity withPuzzleBuilders(List<PuzzleEntity> puzzleEntities) {
+        // TODO SVR-94
+        this.puzzleEntities = puzzleEntities;
+        return this;
+    }
+
+    public Integer getGooglePlaceId() {
+        return googlePlaceId;
+    }
+    /* FUTURE */
+
+    public AttractionEntity withGooglePlaceId(Integer googlePlaceId) {
+        this.googlePlaceId = googlePlaceId;
+        return this;
+    }
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionNotFoundException.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.clueride.domain.attraction;
+
+public class AttractionNotFoundException extends RuntimeException {
+
+    public AttractionNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionService.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionService.java
@@ -1,0 +1,5 @@
+package com.clueride.domain.attraction;
+
+public interface AttractionService {
+    Attraction getById(Integer attractionId);
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionServiceImpl.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionServiceImpl.java
@@ -1,0 +1,24 @@
+package com.clueride.domain.attraction;
+
+import javax.inject.Inject;
+
+/**
+ * Implementation of {@link AttractionService} interface.
+ */
+public class AttractionServiceImpl implements AttractionService {
+
+    private final AttractionStore attractionStore;
+
+    @Inject
+    public AttractionServiceImpl(
+            AttractionStore attractionStore
+    ) {
+        this.attractionStore = attractionStore;
+    }
+
+    @Override
+    public Attraction getById(Integer attractionId) {
+        return attractionStore.getById(attractionId).build();
+    }
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionStore.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionStore.java
@@ -1,0 +1,14 @@
+package com.clueride.domain.attraction;
+
+public interface AttractionStore {
+
+    /**
+     * Given an attractionId, return the corresponding AttractionEntity.
+     *
+     * @param attractionId unique identifier for the Attraction.
+     * @return instance of AttractionEntity or throw AttractionNotFoundException
+     * if not present.
+     */
+    AttractionEntity getById(Integer attractionId);
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionStoreJpa.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionStoreJpa.java
@@ -1,0 +1,16 @@
+package com.clueride.domain.attraction;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+public class AttractionStoreJpa implements AttractionStore {
+
+    @PersistenceContext(unitName="clueride")
+    private EntityManager entityManager;
+
+    @Override
+    public AttractionEntity getById(Integer attractionId) {
+        return entityManager.find(AttractionEntity.class, attractionId);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/attraction/AttractionWebService.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionWebService.java
@@ -1,0 +1,28 @@
+package com.clueride.domain.attraction;
+
+import com.clueride.auth.Secured;
+import com.clueride.domain.location.Location;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * REST API for {@link Location} instances
+ */
+@Path("attraction")
+public class AttractionWebService {
+    @Inject
+    private AttractionService attractionService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public Attraction getById(@QueryParam("id") Integer attractionId) {
+        return attractionService.getById(attractionId);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/flag/FlagEntity.java
+++ b/src/main/java/com/clueride/domain/flag/FlagEntity.java
@@ -6,7 +6,6 @@ import com.clueride.domain.flag.reason.FlagReason;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.jboss.weld.inject.WeldInstance;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
@@ -19,9 +18,6 @@ public class FlagEntity {
     @Transient
     private static Logger LOGGER;
 
-    @Transient
-    private static WeldInstance<FlagEntity> instanceSource;
-
     @Id
     @GeneratedValue(strategy= GenerationType.SEQUENCE, generator = "flag_pk_sequence")
     @SequenceGenerator(name="flag_pk_sequence", sequenceName = "flag_id_seq", allocationSize = 1)
@@ -33,7 +29,7 @@ public class FlagEntity {
     @Column
     private FlagReason reason;
 
-    @Column
+    @Column(name="attribute")
     private FlaggedAttribute flaggedAttribute;
 
     @Column

--- a/src/main/java/com/clueride/domain/flag/FlagService.java
+++ b/src/main/java/com/clueride/domain/flag/FlagService.java
@@ -1,0 +1,29 @@
+package com.clueride.domain.flag;
+
+import com.clueride.domain.attraction.AttractionNotFoundException;
+
+import java.util.List;
+
+/**
+ * Defines operations on Flag instances.
+ */
+public interface FlagService {
+
+    /**
+     * Retrieves full list of all Flags against all Attractions.
+     *
+     * @return full list of all Flags.
+     */
+    List<Flag> getAllFlags();
+
+    /**
+     * Creates new instance of Flag against a specific Attraction.
+     *
+     * Throws AttractionNotFoundException if the Attraction doesn't exist in the DB.
+     *
+     * @param flag instance to be created against an Attraction.
+     * @return The newly added Flag record.
+     */
+    Flag addNewFlag(FlagEntity flag) throws AttractionNotFoundException;
+
+}

--- a/src/main/java/com/clueride/domain/flag/FlagServiceImpl.java
+++ b/src/main/java/com/clueride/domain/flag/FlagServiceImpl.java
@@ -1,0 +1,63 @@
+package com.clueride.domain.flag;
+
+import com.clueride.domain.attraction.Attraction;
+import com.clueride.domain.attraction.AttractionNotFoundException;
+import com.clueride.domain.attraction.AttractionService;
+import com.clueride.domain.flag.reason.FlagReason;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class FlagServiceImpl implements FlagService {
+    private final FlagStore flagStore;
+    private final AttractionService attractionService;
+
+    @Inject
+    public FlagServiceImpl(
+            FlagStore flagStore,
+            AttractionService attractionService
+    ) {
+        this.flagStore = flagStore;
+        this.attractionService = attractionService;
+    }
+
+    @Override
+    public List<Flag> getAllFlags() {
+        List<Flag> flags = new ArrayList<>();
+        for (FlagEntity flagEntity : flagStore.getFlags()) {
+            flags.add(flagEntity.build());
+        }
+        return flags;
+    }
+
+    @Override
+    public Flag addNewFlag(FlagEntity flagEntity) throws AttractionNotFoundException {
+        Integer attractionId = requireNonNull(flagEntity.getAttractionId(), "Attraction ID must be provided");
+        Attraction attraction = attractionService.getById(attractionId);
+        if (attraction == null) {
+            throw new AttractionNotFoundException("Attraction ID " + attractionId + " not found");
+        }
+
+        validate(flagEntity);
+
+        flagStore.addNew(flagEntity);
+        return flagEntity.build();
+    }
+
+    private void validate(FlagEntity flagEntity) {
+//        FlaggedAttribute flaggedAttribute = requireNonNull(
+//                flagEntity.getFlaggedAttribute(),
+//                "Flagged Attribute cannot be null"
+//        );
+
+        FlagReason reason = requireNonNull(
+                flagEntity.getReason(),
+                "Flag Reason cannot be null"
+        );
+    }
+
+
+}

--- a/src/main/java/com/clueride/domain/flag/FlagStore.java
+++ b/src/main/java/com/clueride/domain/flag/FlagStore.java
@@ -1,0 +1,29 @@
+package com.clueride.domain.flag;
+
+import java.util.List;
+
+public interface FlagStore {
+    /**
+     * Retrieves list of all Flags across all Attractions.
+     *
+     * @return Full List of {@link FlagEntity}.
+     */
+    List<FlagEntity> getFlags();
+
+    /**
+     * Persists a new instance of FlagEntity against a specific Attraction.
+     *
+     * @param flagEntity instance to be created.
+     * @return Unique identifier assigned by the database.
+     */
+    Integer addNew(FlagEntity flagEntity);
+
+    /**
+     * Update an existing FlagEntity with the data in this instance.
+     *
+     * @param flagEntity instance to update containing new attributes.
+     * @return the updated instance.
+     */
+    FlagEntity update(FlagEntity flagEntity);
+
+}

--- a/src/main/java/com/clueride/domain/flag/FlagStoreJpa.java
+++ b/src/main/java/com/clueride/domain/flag/FlagStoreJpa.java
@@ -1,0 +1,38 @@
+package com.clueride.domain.flag;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.*;
+import java.util.List;
+
+public class FlagStoreJpa implements FlagStore {
+
+    @PersistenceContext(unitName = "clueride")
+    private EntityManager entityManager;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @Override
+    public Integer addNew(FlagEntity flagEntity) {
+        try {
+                userTransaction.begin();
+                entityManager.persist(flagEntity);
+                userTransaction.commit();
+        } catch (NotSupportedException | SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e) {
+            e.printStackTrace();
+        }
+        return flagEntity.getId();
+    }
+
+    @Override
+    public List<FlagEntity> getFlags() {
+        return entityManager.createQuery("SELECT f FROM FlagEntity f").getResultList();
+    }
+
+    @Override
+    public FlagEntity update(FlagEntity flagEntity) {
+        return null;
+    }
+}

--- a/src/main/java/com/clueride/domain/flag/FlagWebService.java
+++ b/src/main/java/com/clueride/domain/flag/FlagWebService.java
@@ -1,0 +1,30 @@
+package com.clueride.domain.flag;
+
+import com.clueride.auth.Secured;
+
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/flag")
+public class FlagWebService {
+    @Inject
+    private FlagService flagService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Flag> getAllFlags() {
+        return flagService.getAllFlags();
+    }
+
+    @POST
+    @Secured
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Flag addNewFlag(FlagEntity flagEntity) {
+        return flagService.addNewFlag(flagEntity);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingStore.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStore.java
@@ -26,11 +26,11 @@ public interface OutingStore {
     /**
      * Accepts fully-populated Outing instance and returns the ID of a newly persisted record.
      *
-     * @param builder - {@link OutingViewEntity} instance which is fully-populated.
+     * @param entity - {@link OutingViewEntity} instance which is fully-populated.
      * @return Integer DB-generated ID.
      * @throws IOException when there is trouble writing to the store.
      */
-    Integer addNew(OutingViewEntity builder) throws IOException;
+    Integer addNew(OutingViewEntity entity) throws IOException;
 
     /**
      * Given a specific Outing Identifier, return the matching {@link Outing} instance.

--- a/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStoreJpa.java
@@ -17,10 +17,9 @@
  */
 package com.clueride.domain.outing;
 
-import java.io.IOException;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +31,7 @@ public class OutingStoreJpa implements OutingStore {
     private EntityManager entityManager;
 
     @Override
-    public Integer addNew(OutingViewEntity builder) throws IOException {
+    public Integer addNew(OutingViewEntity entity) throws IOException {
         return null;
     }
 

--- a/src/test/java/com/clueride/domain/flag/TestResources.java
+++ b/src/test/java/com/clueride/domain/flag/TestResources.java
@@ -1,0 +1,24 @@
+package com.clueride.domain.flag;
+
+import com.clueride.domain.flag.details.FlaggedAttribute;
+import com.clueride.domain.flag.reason.FlagReason;
+import com.clueride.util.TestOnly;
+
+import javax.ws.rs.Produces;
+
+public class TestResources {
+
+    @Produces
+    @TestOnly
+    FlagEntity produceFlagEntity() {
+        return FlagEntity.builder()
+                .withId(123)
+                .withAttractionId(100)
+                .withReason(FlagReason.FUN_FACTOR)
+                .withFlaggedAttribute(FlaggedAttribute.MAIN_LINK)
+                .withDescription("Link is no longer reachable")
+                .withOpenBadgeEventId(13)
+                ;
+    }
+
+}


### PR DESCRIPTION
- Provides REST API to save new flag instances to the DB.
- Provides REST API to retrieve list of all Flag instances (open or otherwise).

- Starts moving Location over to Attraction.

Also some pom.xml cleanup.