### PR TITLE
SVR-101 Attraction API should provide a set of Flags against the Attr…

### DIFF
--- a/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
@@ -17,19 +17,13 @@
  */
 package com.clueride.domain.account.member;
 
-import java.util.List;
-
 import javax.annotation.Resource;
 import javax.enterprise.context.ApplicationScoped;
 import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import javax.transaction.*;
+import java.util.List;
 
 /**
  * JPA Implementation of the MemberStore (DAO) interface.
@@ -86,14 +80,18 @@ public class MemberStoreJpa implements MemberStore {
 
     @Override
     public List<MemberEntity> getAllMembers() {
-        return entityManager.createQuery("SELECT m FROM MemberEntity m").getResultList();
+        return entityManager.createQuery(
+                "SELECT m FROM MemberEntity m",
+                MemberEntity.class
+        ).getResultList();
     }
 
     @Override
     public List<MemberEntity> getMatchingMembers(String pattern) {
         return entityManager.createQuery(
                 "SELECT m FROM MemberEntity m " +
-                        " WHERE lower(m.displayName) like :pattern"
+                        " WHERE lower(m.displayName) like :pattern",
+                MemberEntity.class
         ).setParameter(
                 "pattern",
                 "%"+pattern.toLowerCase()+"%")

--- a/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
+++ b/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
@@ -17,11 +17,10 @@
  */
 package com.clueride.domain.account.principal;
 
-import java.util.List;
-
 import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +49,10 @@ public class BadgeOsPrincipalStoreJpa implements BadgeOsPrincipalStore {
 
     @Override
     public List<BadgeOsPrincipalEntity> getAll() {
-        return entityManager.createQuery("SELECT p FROM BadgeOsPrincipalEntity p").getResultList();
+        return entityManager.createQuery(
+                "SELECT p FROM BadgeOsPrincipalEntity p",
+                BadgeOsPrincipalEntity.class
+        ).getResultList();
     }
 
 }

--- a/src/main/java/com/clueride/domain/achievement/AchievementStoreJpa.java
+++ b/src/main/java/com/clueride/domain/achievement/AchievementStoreJpa.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.achievement;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.slf4j.Logger;
+import java.util.List;
 
 /**
  * JPA-based implementation of {@link AchievementStore}.
@@ -37,15 +36,18 @@ public class AchievementStoreJpa implements AchievementStore {
 
     @Override
     public List<AchievementEntity> getAllAchievements() {
-        return entityManager.createQuery("SELECT ach FROM AchievementEntity ach")
-                .getResultList();
+        return entityManager.createQuery(
+                "SELECT ach FROM AchievementEntity ach",
+                AchievementEntity.class
+        ).getResultList();
     }
 
     @Override
     public List<AchievementEntity> getAchievementsForUser(Integer userId) {
         return entityManager.createQuery("SELECT ach FROM AchievementEntity ach " +
-                "WHERE ach.userId = :userId")
-                .setParameter("userId", userId)
+                "WHERE ach.userId = :userId",
+                AchievementEntity.class
+        ).setParameter("userId", userId)
                 .getResultList();
     }
 

--- a/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStoreJpa.java
+++ b/src/main/java/com/clueride/domain/achievement/map/ArrivalStepStoreJpa.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.achievement.map;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.slf4j.Logger;
+import java.util.List;
 
 /**
  * JPA implementation of {@link ArrivalStepStore}.
@@ -41,7 +40,8 @@ public class ArrivalStepStoreJpa implements ArrivalStepStore {
         LOGGER.debug("Retrieving all Steps");
         List<ArrivalStepEntity> entities;
         entities = entityManager.createQuery(
-                "SELECT s FROM ArrivalStepEntity s"
+                "SELECT s FROM ArrivalStepEntity s",
+                ArrivalStepEntity.class
         ).getResultList();
         return entities;
     }

--- a/src/main/java/com/clueride/domain/achievement/map/PageStepsStoreJpa.java
+++ b/src/main/java/com/clueride/domain/achievement/map/PageStepsStoreJpa.java
@@ -17,10 +17,9 @@
  */
 package com.clueride.domain.achievement.map;
 
-import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
 
 /**
  * JPA-based implementation of {@link PageStepsStore}.
@@ -32,7 +31,8 @@ public class PageStepsStoreJpa implements PageStepsStore {
     @Override
     public List<PageStepEntity> getAllRecords() {
         return entityManager.createQuery(
-                "SELECT p2s from PageStepEntity p2s"
+                "SELECT p2s from PageStepEntity p2s",
+                PageStepEntity.class
         ).getResultList();
     }
 

--- a/src/main/java/com/clueride/domain/attraction/AttractionStore.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionStore.java
@@ -1,5 +1,7 @@
 package com.clueride.domain.attraction;
 
+import java.util.List;
+
 public interface AttractionStore {
 
     /**
@@ -10,5 +12,14 @@ public interface AttractionStore {
      * if not present.
      */
     AttractionEntity getById(Integer attractionId);
+
+    /**
+     * Retrieve all Attractions.
+     *
+     * Filtering for this particular call would happen client-side.
+     *
+     * @return List of all Attraction instances.
+     */
+    List<AttractionEntity> getAllAttractions();
 
 }

--- a/src/main/java/com/clueride/domain/attraction/AttractionStoreJpa.java
+++ b/src/main/java/com/clueride/domain/attraction/AttractionStoreJpa.java
@@ -2,6 +2,7 @@ package com.clueride.domain.attraction;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
 
 public class AttractionStoreJpa implements AttractionStore {
 
@@ -15,6 +16,14 @@ public class AttractionStoreJpa implements AttractionStore {
             throw new AttractionNotFoundException("Attraction ID " + attractionId + " not found");
         }
         return entity;
+    }
+
+    @Override
+    public List<AttractionEntity> getAllAttractions() {
+        return entityManager.createQuery(
+                "SELECT a FROM AttractionEntity a",
+                AttractionEntity.class
+        ).getResultList();
     }
 
 }

--- a/src/main/java/com/clueride/domain/attraction/FlaggedAttractionService.java
+++ b/src/main/java/com/clueride/domain/attraction/FlaggedAttractionService.java
@@ -1,5 +1,7 @@
 package com.clueride.domain.attraction;
 
+import java.util.List;
+
 public interface FlaggedAttractionService {
 
     /**
@@ -11,5 +13,13 @@ public interface FlaggedAttractionService {
      * AttractionNotFoundException if no matching AttractionID.
      */
     Attraction getByIdWithFlags(Integer attractionId);
+
+    /**
+     * Retrieve all Attractions and populate with any issues those attractions
+     * may have.
+     *
+     * @return List of all Attractions with their Flags populated.
+     */
+    List<Attraction> getAllAttractions();
 
 }

--- a/src/main/java/com/clueride/domain/attraction/FlaggedAttractionWebService.java
+++ b/src/main/java/com/clueride/domain/attraction/FlaggedAttractionWebService.java
@@ -8,12 +8,20 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 
 @Path("flagged-attraction")
 public class FlaggedAttractionWebService {
 
     @Inject
     private FlaggedAttractionService flaggedAttractionService;
+
+    @GET
+    @Secured
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Attraction> getAllAttractions() {
+        return flaggedAttractionService.getAllAttractions();
+    }
 
     @GET
     @Secured

--- a/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.badge;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.slf4j.Logger;
+import java.util.List;
 
 /**
  * JPA implementation of Badge Store.
@@ -41,7 +40,8 @@ public class BadgeStoreJpa implements BadgeStore {
         LOGGER.debug("Retrieving Badges for User ID {}", userId);
         List<BadgeEntity> builderList;
         builderList = entityManager.createQuery(
-                    "SELECT b FROM BadgeEntity b WHERE b.userId = :userId"
+                "SELECT b FROM BadgeEntity b WHERE b.userId = :userId",
+                BadgeEntity.class
         )
                 .setParameter("userId", userId)
                 .getResultList();

--- a/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/features/BadgeFeaturesStoreJpa.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.badge.features;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.slf4j.Logger;
+import java.util.List;
 
 /**
  * JPA implementation of {@link BadgeFeaturesStore}.
@@ -41,7 +40,9 @@ public class BadgeFeaturesStoreJpa implements BadgeFeaturesStore {
         LOGGER.debug("Retrieving full list of Badges/Achievements that can be earned");
         List<BadgeFeaturesEntity> badgeFeaturesEntityList;
         badgeFeaturesEntityList = entityManager.createQuery(
-               "SELECT bfe FROM BadgeFeaturesEntity bfe"
+               "SELECT bfe FROM BadgeFeaturesEntity bfe",
+                BadgeFeaturesEntity.class
+
         ).getResultList();
         return badgeFeaturesEntityList;
     }
@@ -52,7 +53,8 @@ public class BadgeFeaturesStoreJpa implements BadgeFeaturesStore {
         List<BadgeFeaturesEntity> badgeFeaturesEntityList;
         badgeFeaturesEntityList = entityManager.createQuery(
                 "SELECT bfe FROM BadgeFeaturesEntity bfe " +
-                        "WHERE bfe.badgeName = 'theme-close-ended' OR bfe.badgeName = 'theme-open-ended'"
+                        "WHERE bfe.badgeName = 'theme-close-ended' OR bfe.badgeName = 'theme-open-ended'",
+                BadgeFeaturesEntity.class
         ).getResultList();
         return badgeFeaturesEntityList;
     }

--- a/src/main/java/com/clueride/domain/badge/theme/ThemeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/badge/theme/ThemeStoreJpa.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.badge.theme;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import org.slf4j.Logger;
+import java.util.List;
 
 /**
  * JPA implementation of {@link ThemeStore}.
@@ -38,28 +37,28 @@ public class ThemeStoreJpa implements ThemeStore {
     @Override
     public List<ThemeEntity> getThemes() {
         LOGGER.debug("Retrieving list of All Themes");
-        List<ThemeEntity> themes = entityManager.createQuery(
-                "SELECT t FROM ThemeEntity t"
+        return entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t",
+                ThemeEntity.class
         ).getResultList();
-        return themes;
     }
 
     @Override
     public List<ThemeEntity> getClosedThemes() {
         LOGGER.debug("Retrieving list of Closed Themes");
-        List<ThemeEntity> themes = entityManager.createQuery(
-                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'closed'"
+        return entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'closed'",
+                ThemeEntity.class
         ).getResultList();
-        return themes;
     }
 
     @Override
     public List<ThemeEntity> getOpenThemes() {
         LOGGER.debug("Retrieving list of Open Themes");
-        List<ThemeEntity> themes = entityManager.createQuery(
-                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'open'"
+        return entityManager.createQuery(
+                "SELECT t FROM ThemeEntity t WHERE t.themeType = 'open'",
+                ThemeEntity.class
         ).getResultList();
-        return themes;
     }
 
 }

--- a/src/main/java/com/clueride/domain/course/CourseStoreJpa.java
+++ b/src/main/java/com/clueride/domain/course/CourseStoreJpa.java
@@ -17,11 +17,10 @@
  */
 package com.clueride.domain.course;
 
-import java.io.IOException;
-import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * JPA-based implementation of CourseStore.
@@ -47,8 +46,10 @@ public class CourseStoreJpa implements CourseStore {
 
     @Override
     public List<CourseEntity> getCourses() {
-        return entityManager.createQuery("SELECT c from CourseEntity c ORDER BY c.name")
-                .getResultList();
+        return entityManager.createQuery(
+                "SELECT c from CourseEntity c ORDER BY c.name",
+                CourseEntity.class
+        ).getResultList();
     }
 
 }

--- a/src/main/java/com/clueride/domain/flag/FlagStoreJpa.java
+++ b/src/main/java/com/clueride/domain/flag/FlagStoreJpa.java
@@ -28,7 +28,10 @@ public class FlagStoreJpa implements FlagStore {
 
     @Override
     public List<FlagEntity> getFlags() {
-        return entityManager.createQuery("SELECT f FROM FlagEntity f").getResultList();
+        return entityManager.createQuery(
+                "SELECT f FROM FlagEntity f",
+                FlagEntity.class
+        ).getResultList();
     }
 
     @Override
@@ -38,8 +41,11 @@ public class FlagStoreJpa implements FlagStore {
 
     @Override
     public List<FlagEntity> getFlagsForAttractions(List<Integer> attractionIds) {
-        return entityManager.createQuery("SELECT f from FlagEntity f WHERE attractionId in :ids")
-                .setParameter("ids", attractionIds)
+        return entityManager.createQuery(
+                "SELECT f from FlagEntity f WHERE attractionId in :ids",
+                FlagEntity.class
+        ).setParameter("ids", attractionIds)
                 .getResultList();
     }
+
 }

--- a/src/main/java/com/clueride/domain/invite/InviteStoreJpa.java
+++ b/src/main/java/com/clueride/domain/invite/InviteStoreJpa.java
@@ -17,21 +17,15 @@
  */
 package com.clueride.domain.invite;
 
-import java.io.IOException;
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
-
-import org.slf4j.Logger;
+import javax.transaction.*;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * JPA persistence for the Invite entity.
@@ -66,10 +60,11 @@ public class InviteStoreJpa implements InviteStore {
         inviteEntities = entityManager.createQuery(
                 "SELECT i FROM InviteEntity i where i.memberId = :memberId AND i.inviteState " +
                         "IN (" +
-                          "com.clueride.domain.invite.InviteState.SENT," +
-                          "com.clueride.domain.invite.InviteState.ACCEPTED," +
-                          "com.clueride.domain.invite.InviteState.DECLINED" +
-                        ")"
+                        "com.clueride.domain.invite.InviteState.SENT," +
+                        "com.clueride.domain.invite.InviteState.ACCEPTED," +
+                        "com.clueride.domain.invite.InviteState.DECLINED" +
+                        ")",
+                InviteEntity.class
         ).setParameter("memberId", memberId)
                 .getResultList();
         return inviteEntities;

--- a/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/LocationStoreJpa.java
@@ -17,22 +17,16 @@
  */
 package com.clueride.domain.location;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
-
-import org.slf4j.Logger;
+import javax.transaction.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * JPA Implementation of the LocationStore (DAO) interface.
@@ -67,7 +61,8 @@ public class LocationStoreJpa implements LocationStore {
     @Override
     public Collection<LocationEntity> getLocationBuilders() {
         List<LocationEntity> locationList = entityManager.createQuery(
-                "SELECT l FROM LocationEntity l"
+                "SELECT l FROM LocationEntity l",
+                LocationEntity.class
         ).getResultList();
         return new ArrayList<>(locationList);
     }
@@ -106,7 +101,8 @@ public class LocationStoreJpa implements LocationStore {
                 "SELECT l FROM LocationEntity l" +
                         " WHERE l.locationTypeId IN (" +
                         "SELECT lt.id from LocationTypeEntity lt WHERE lt.themeId IN (" +
-                        "SELECT t.id from ThemeEntity t) )"
+                        "SELECT t.id from ThemeEntity t) )",
+                LocationEntity.class
         ).getResultList();
         return new ArrayList<>(locationList);
     }

--- a/src/main/java/com/clueride/domain/location/category/CategoryStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/category/CategoryStoreJpa.java
@@ -17,10 +17,9 @@
  */
 package com.clueride.domain.location.category;
 
-import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
 
 /**
  * JPA implementation of {@link CategoryStore}.
@@ -33,7 +32,8 @@ public class CategoryStoreJpa implements CategoryStore {
     @Override
     public List<CategoryEntity> fetchAll() {
         return entityManager.createQuery(
-                "SELECT c FROM CategoryEntity c order by c.name"
+                "SELECT c FROM CategoryEntity c order by c.name",
+                CategoryEntity.class
         ).getResultList();
     }
 

--- a/src/main/java/com/clueride/domain/location/loclink/LocLinkStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/loclink/LocLinkStoreJpa.java
@@ -17,17 +17,11 @@
  */
 package com.clueride.domain.location.loclink;
 
-import java.util.List;
-
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import javax.transaction.*;
+import java.util.List;
 
 /**
  * JPA implementation of {@link LocLinkStore}.
@@ -56,7 +50,8 @@ public class LocLinkStoreJpa implements LocLinkStore {
     public LocLinkEntity findByUrl(String locLinkText) {
         List<LocLinkEntity> locLinkEntities =  entityManager.createQuery(
                 "SELECT l from LocLinkEntity l " +
-                        " WHERE l.link = :linkText"
+                        " WHERE l.link = :linkText",
+                LocLinkEntity.class
         )
                 .setParameter("linkText", locLinkText)
                 /* getSingleResult would throw an exception which is a bother. */

--- a/src/main/java/com/clueride/domain/location/loctype/LocationTypeStoreJpa.java
+++ b/src/main/java/com/clueride/domain/location/loctype/LocationTypeStoreJpa.java
@@ -17,11 +17,10 @@
  */
 package com.clueride.domain.location.loctype;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * JPA implementation of the LocationTypeStore (DAO).
@@ -35,7 +34,8 @@ public class LocationTypeStoreJpa implements LocationTypeStore {
         List<LocationType> locationTypes = new ArrayList<>();
         List<LocationTypeEntity> locTypeBuilders =
                 entityManager.createQuery(
-                        "SELECT lt from LocationTypeEntity lt"
+                        "SELECT lt from LocationTypeEntity lt",
+                        LocationTypeEntity.class
                 ).getResultList();
 
         for (LocationTypeEntity locTypeBuilder : locTypeBuilders) {
@@ -48,7 +48,8 @@ public class LocationTypeStoreJpa implements LocationTypeStore {
     public LocationType getLocationTypeByName(String locationTypeName) {
 
         List<LocationTypeEntity> locationTypeEntities = entityManager.createQuery(
-                "SELECT lt FROM LocationTypeEntity lt WHERE lt.name = :locTypeName"
+                "SELECT lt FROM LocationTypeEntity lt WHERE lt.name = :locTypeName",
+                LocationTypeEntity.class
         ).setParameter("locTypeName", locationTypeName)
                 .getResultList();
 

--- a/src/main/java/com/clueride/domain/page/PageStoreJpa.java
+++ b/src/main/java/com/clueride/domain/page/PageStoreJpa.java
@@ -31,7 +31,7 @@ public class PageStoreJpa implements PageStore {
     public PageEntity getPageBySlug(String slug) {
 
         return entityManager.createQuery(
-                "SELECT p from Page p " +
+                "SELECT p from PageEntity p " +
                         "WHERE p.pageSlug = :slug",
                     PageEntity.class
                 )

--- a/src/main/java/com/clueride/domain/path/PathForCourseStoreJpa.java
+++ b/src/main/java/com/clueride/domain/path/PathForCourseStoreJpa.java
@@ -17,10 +17,9 @@
  */
 package com.clueride.domain.path;
 
-import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.List;
 
 /**
  * JPA-implementation of {@link PathForCourseStore}.
@@ -35,7 +34,8 @@ public class PathForCourseStoreJpa implements PathForCourseStore {
         builders = entityManager.createQuery(
                "SELECT p FROM PathForCourseEntity p " +
                        " WHERE p.courseId = :courseId" +
-                       " ORDER BY p.pathOrder"
+                       " ORDER BY p.pathOrder",
+                PathForCourseEntity.class
         ).setParameter(
                 "courseId", courseId
         ).getResultList();

--- a/src/main/java/com/clueride/domain/place/ScoredLocationService.java
+++ b/src/main/java/com/clueride/domain/place/ScoredLocationService.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.place;
 
+import com.clueride.domain.attraction.AttractionEntity;
 import com.clueride.domain.location.LocationEntity;
 import com.clueride.domain.location.ReadinessLevel;
 
@@ -30,5 +31,19 @@ public interface ScoredLocationService {
      * @return Readiness Level
      */
     ReadinessLevel calculateReadinessLevel(LocationEntity location);
+
+    /**
+     * Given an AttractionEntity from the dataStore, compute the Readiness level
+     * for that Attraction.
+     *
+     * This is orthogonal to any Flags on the Attraction, but obviously, if
+     * an Attraction has Flags, then it isn't ready. In geneneral however,
+     * only Attractions which have reached the level of Attraction would be
+     * flagged.
+     *
+     * @param attractionEntity to be evaluated.
+     * @return Readiness Level for the Attraction.
+     */
+    ReadinessLevel calculateReadinessLevel(AttractionEntity attractionEntity);
 
 }

--- a/src/main/java/com/clueride/domain/place/ScoredLocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/place/ScoredLocationServiceImpl.java
@@ -17,14 +17,15 @@
  */
 package com.clueride.domain.place;
 
-import java.util.List;
-
-import javax.inject.Inject;
-
+import com.clueride.domain.attraction.AttractionEntity;
 import com.clueride.domain.location.LocationEntity;
 import com.clueride.domain.location.ReadinessLevel;
 import com.clueride.domain.puzzle.Puzzle;
 import com.clueride.domain.puzzle.PuzzleService;
+
+import javax.inject.Inject;
+import java.util.List;
+
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
@@ -43,7 +44,7 @@ public class ScoredLocationServiceImpl implements ScoredLocationService {
 
     @Override
     public ReadinessLevel calculateReadinessLevel(LocationEntity location) {
-                /* Emptiness across all of these makes it a NODE. */
+        /* Emptiness across all of these makes it a NODE. */
         if (isNullOrEmpty(location.getName())
                 && isNullOrEmpty(location.getDescription())
                 && location.getFeaturedImage() == null
@@ -69,6 +70,40 @@ public class ScoredLocationServiceImpl implements ScoredLocationService {
 
         /* If everything else is defined except our Google Place ID, we're an Attraction. */
         if (location.getGooglePlaceId() == null) {
+            return ReadinessLevel.ATTRACTION;
+        } else {
+            return ReadinessLevel.FEATURED;
+        }
+    }
+
+    @Override
+    public ReadinessLevel calculateReadinessLevel(AttractionEntity attractionEntity) {
+        /* Emptiness across all of these makes it a NODE. */
+        if (isNullOrEmpty(attractionEntity.getName())
+                && isNullOrEmpty(attractionEntity.getDescription())
+                && attractionEntity.getFeaturedImage() == null
+                && attractionEntity.getLocationTypeId() == 0
+        ) {
+            return ReadinessLevel.NODE;
+        }
+
+        /* Handle anything that could make this a draft. */
+        if (isNullOrEmpty(attractionEntity.getName())
+                || isNullOrEmpty(attractionEntity.getDescription())
+                || attractionEntity.getFeaturedImage() == null
+                || attractionEntity.getLocationTypeId() == 0
+        ) {
+            return ReadinessLevel.DRAFT;
+        }
+
+        /* If we're missing the Puzzles, we're just a Place. */
+        List<Puzzle> puzzles = puzzleService.getByLocation(attractionEntity.getId());
+        if (puzzles.size() == 0) {
+            return ReadinessLevel.PLACE;
+        }
+
+        /* If everything else is defined except our Google Place ID, we're an Attraction. */
+        if (attractionEntity.getGooglePlaceId() == null) {
             return ReadinessLevel.ATTRACTION;
         } else {
             return ReadinessLevel.FEATURED;

--- a/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
+++ b/src/main/java/com/clueride/domain/puzzle/PuzzleStoreJpa.java
@@ -17,19 +17,13 @@
  */
 package com.clueride.domain.puzzle;
 
-import java.util.List;
+import com.clueride.domain.location.LocationEntity;
 
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
-
-import com.clueride.domain.location.LocationEntity;
+import javax.transaction.*;
+import java.util.List;
 
 /**
  * Implementation of the Puzzle Store.
@@ -65,8 +59,9 @@ public class PuzzleStoreJpa implements PuzzleStore {
     public List<PuzzleEntity> getPuzzlesForLocation(LocationEntity locationEntity) {
         List<PuzzleEntity> puzzleEntities;
         puzzleEntities = entityManager.createQuery(
-                        "SELECT p FROM PuzzleEntity p where p.locationEntity = :locationEntity"
-                ).setParameter("locationEntity", locationEntity)
+                "SELECT p FROM PuzzleEntity p where p.locationEntity = :locationEntity",
+                PuzzleEntity.class
+        ).setParameter("locationEntity", locationEntity)
                 .getResultList();
         return puzzleEntities;
     }

--- a/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
+++ b/src/main/java/com/clueride/domain/team/TeamStoreJpa.java
@@ -17,20 +17,14 @@
  */
 package com.clueride.domain.team;
 
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
-
-import org.slf4j.Logger;
+import javax.transaction.*;
+import java.util.List;
 
 /**
  * JPA implementation of {@link TeamStore}.
@@ -68,10 +62,11 @@ public class TeamStoreJpa implements TeamStore {
         LOGGER.info("Retrieving full list of Teams");
         return (List<TeamEntity>) entityManager.createQuery(
                 "SELECT t FROM TeamEntity t " +
-                "left outer join OutingViewEntity o " +
-                "on o.teamId = t.id " +
-                "order by o.courseId, " +
-                "o.scheduledTime desc"
+                        "left outer join OutingViewEntity o " +
+                        "on o.teamId = t.id " +
+                        "order by o.courseId, " +
+                        "o.scheduledTime desc",
+                TeamEntity.class
         ).getResultList();
     }
 


### PR DESCRIPTION
…action when requested

- Adds new API endpoint to replace `LocationService.nearest()` that fills the flags for each Attraction.
- Adds Service and DataStore to support the endpoint -- chipping away at the LocationService and what it provides.

When touching the DataStore layer, I bumped into the casting warning and (re)learned that it is because I wasn't
passing the type to the `createQuery()` call. This commit contains the work to go back and correct all of these.