### PR TITLE
SVR-108 Make sure Member Account is generated if missing

### DIFF
--- a/src/main/java/com/clueride/auth/InvalidAuthTokenException.java
+++ b/src/main/java/com/clueride/auth/InvalidAuthTokenException.java
@@ -1,0 +1,14 @@
+package com.clueride.auth;
+
+/**
+ * Thrown when the Auth Token is invalid.
+ *
+ * Details of the reason are provided within the detailMessage.
+ */
+public class InvalidAuthTokenException extends RuntimeException {
+
+    public InvalidAuthTokenException(String detailMessage) {
+        super(detailMessage);
+    }
+
+}

--- a/src/main/java/com/clueride/auth/access/AccessTokenService.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenService.java
@@ -17,12 +17,14 @@
  */
 package com.clueride.auth.access;
 
-import java.util.concurrent.ExecutionException;
-
 import com.clueride.auth.identity.ClueRideIdentity;
+
+import java.util.concurrent.ExecutionException;
 
 /**
  * Describes the features provided for Access Tokens.
+ *
+ * Much of this service is backed by a 3rd-party Auth service.
  */
 public interface AccessTokenService {
     /**
@@ -69,5 +71,10 @@ public interface AccessTokenService {
      * @return true if the represented session is active.
      */
     boolean isSessionActive(String token);
+
+    /**
+     * Given the Auth Header, validate that there is an Access Token that can be obtained.
+     */
+    void validateAuthHeader(String authHeader);
 
 }

--- a/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
+++ b/src/main/java/com/clueride/auth/access/AccessTokenServiceImpl.java
@@ -17,22 +17,21 @@
  */
 package com.clueride.auth.access;
 
-import java.io.Serializable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-
+import com.clueride.RecordNotFoundException;
+import com.clueride.auth.InvalidAuthTokenException;
+import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.auth.identity.IdentityStore;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.slf4j.Logger;
 
-import com.clueride.RecordNotFoundException;
-import com.clueride.auth.identity.ClueRideIdentity;
-import com.clueride.auth.identity.IdentityStore;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.Serializable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of AccessTokenService.
@@ -98,6 +97,16 @@ public class AccessTokenServiceImpl implements AccessTokenService, Serializable 
     @Override
     public boolean isSessionActive(String token) {
         return identityCache.asMap().containsKey(token);
+    }
+
+    @Override
+    public void validateAuthHeader(String authHeader) {
+        if (authHeader == null) {
+            throw new InvalidAuthTokenException("No Auth Header provided");
+        };
+        if (!authHeader.startsWith("Bearer ")) {
+            throw new InvalidAuthTokenException("Auth Header missing the word 'Bearer'");
+        }
     }
 
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
@@ -17,14 +17,14 @@
  */
 package com.clueride.auth.session;
 
-import java.io.Serializable;
-
 import com.clueride.auth.identity.ClueRideIdentity;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.invite.Invite;
 import com.clueride.domain.outing.OutingView;
 import com.clueride.domain.puzzle.state.PuzzleState;
+
+import java.io.Serializable;
 
 /**
  * "Holder" for session-related class instances.
@@ -83,6 +83,11 @@ public class ClueRideSessionDto implements Serializable {
 
     public PuzzleState getPuzzleState() {
         return puzzleState;
+    }
+
+    /** Convenience method. */
+    public boolean hasNoOuting() {
+        return (this.outingView == null);
     }
 
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionProducer.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionProducer.java
@@ -17,28 +17,14 @@
  */
 package com.clueride.auth.session;
 
-import java.io.Serializable;
-import java.util.List;
+import org.slf4j.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-
-import org.slf4j.Logger;
-
-import com.clueride.RecordNotFoundException;
-import com.clueride.auth.access.AccessTokenService;
-import com.clueride.auth.identity.ClueRideIdentity;
-import com.clueride.domain.account.member.Member;
-import com.clueride.domain.account.member.MemberService;
-import com.clueride.domain.account.principal.BadgeOsPrincipalService;
-import com.clueride.domain.invite.Invite;
-import com.clueride.domain.invite.InviteService;
-import com.clueride.domain.outing.OutingService;
-import com.clueride.domain.outing.OutingView;
-import static java.util.Objects.requireNonNull;
+import java.io.Serializable;
 
 /**
  * Responds to the Event that requests placing Principal instances into user's session.
@@ -51,22 +37,7 @@ public class ClueRideSessionProducer implements Serializable {
     private Logger LOGGER;
 
     @Inject
-    private AccessTokenService accessTokenService;
-
-    @Inject
-    private BadgeOsPrincipalService badgeOsPrincipalService;
-
-    @Inject
     private ClueRideSessionService clueRideSessionService;
-
-    @Inject
-    private InviteService inviteService;
-
-    @Inject
-    private MemberService memberService;
-
-    @Inject
-    private OutingService outingService;
 
 
     private String accessToken;
@@ -81,63 +52,6 @@ public class ClueRideSessionProducer implements Serializable {
     @ClueRideSession
     /* Invoked once per session, but maintaining session is tricky across platforms. */
     private ClueRideSessionDto produceClueRideSessionDto() {
-        requireNonNull(accessToken, "Empty Token. Is this endpoint behind the @Secured annotation?");
-        ClueRideSessionDto clueRideSessionDto = clueRideSessionService.getSessionFromToken(accessToken);
-
-        /* Check if we already have a session object for this token ... */
-        if (clueRideSessionDto != null) {
-            return clueRideSessionDto;
-        }
-
-        /* ... if not, create a new one. */
-        clueRideSessionDto = new ClueRideSessionDto();
-
-        ClueRideIdentity clueRideIdentity = accessTokenService.getIdentity(accessToken);
-        clueRideSessionDto.setClueRideIdentity(clueRideIdentity);
-
-        String emailAddressString = addBadgeOsPrincipal(clueRideSessionDto, clueRideIdentity);
-        LOGGER.debug("Instantiating a new Session DTO for {}", emailAddressString);
-
-        Integer memberId = addMember(clueRideSessionDto, clueRideIdentity, emailAddressString);
-
-        if (memberId != null) {
-            addInviteAndOuting(clueRideSessionDto, memberId);
-        }
-
-        clueRideSessionService.setSessionForToken(accessToken, clueRideSessionDto);
-        return clueRideSessionDto;
+        return clueRideSessionService.loadSessionForExistingAccount(accessToken);
     }
-
-    private String addBadgeOsPrincipal(ClueRideSessionDto clueRideSessionDto, ClueRideIdentity clueRideIdentity) {
-        String emailAddressString = clueRideIdentity.getEmail().toString();
-        clueRideSessionDto.setBadgeOSPrincipal(badgeOsPrincipalService.getBadgeOsPrincipal(clueRideIdentity.getEmail()));
-        return emailAddressString;
-    }
-
-    private Integer addMember(ClueRideSessionDto clueRideSessionDto, ClueRideIdentity clueRideIdentity, String emailAddressString) {
-        Integer memberId = null;
-        try {
-            Member member = memberService.getMemberByEmail(clueRideIdentity.getEmail());
-            clueRideSessionDto.setMember(member);
-            memberId = member.getId();
-        } catch (RecordNotFoundException rnfe) {
-            // TODO: CA-409 (maybe throw RuntimeException about data records amiss?)
-            LOGGER.error("Unable to find member record for email: {}", emailAddressString);
-        }
-        return memberId;
-    }
-
-    private void addInviteAndOuting(ClueRideSessionDto clueRideSessionDto, Integer memberId) {
-        List<Invite> invites = inviteService.getMemberInvites(memberId);
-        if (invites.size() > 0) {
-            /* The session only cares about the next one coming up. */
-            Invite invite = invites.get(0);
-            clueRideSessionDto.setInvite(invite);
-
-            /* Check if we can retrieve the Outing. */
-            OutingView outingView = outingService.getViewById(invite.getOutingId());
-            clueRideSessionDto.setOutingView(outingView);
-        }
-    }
-
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionService.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionService.java
@@ -36,4 +36,13 @@ public interface ClueRideSessionService {
      */
     void setSessionForToken(String token, ClueRideSessionDto sessionDto);
 
+    /**
+     * Given the Access Token, look up and populate the Session instance
+     * for an existing Member.
+     *
+     * @param accessToken unique and opaque token representing the user's active session.
+     * @return Session instance populated with values appropriate to the user's session.
+     */
+    ClueRideSessionDto loadSessionForExistingAccount(String accessToken);
+
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
@@ -17,8 +17,24 @@
  */
 package com.clueride.auth.session;
 
+import com.clueride.RecordNotFoundException;
+import com.clueride.auth.access.AccessTokenService;
+import com.clueride.auth.identity.ClueRideIdentity;
+import com.clueride.domain.account.member.Member;
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.principal.BadgeOsPrincipalService;
+import com.clueride.domain.invite.Invite;
+import com.clueride.domain.invite.InviteService;
+import com.clueride.domain.outing.OutingService;
+import com.clueride.domain.outing.OutingView;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of {@link ClueRideSessionService} backed by a simple Map.
@@ -26,6 +42,24 @@ import java.util.Map;
  * TODO: This needs to be reconstructed so it's members can be expired.
  */
 public class ClueRideSessionServiceImpl implements ClueRideSessionService {
+    @Inject
+    private Logger LOGGER;
+
+    @Inject
+    private AccessTokenService accessTokenService;
+
+    @Inject
+    private BadgeOsPrincipalService badgeOsPrincipalService;
+
+    @Inject
+    private InviteService inviteService;
+
+    @Inject
+    private MemberService memberService;
+
+    @Inject
+    private OutingService outingService;
+
     private static Map<String, ClueRideSessionDto> sessionMap = new HashMap<>();
 
     @Override
@@ -36,6 +70,69 @@ public class ClueRideSessionServiceImpl implements ClueRideSessionService {
     @Override
     public void setSessionForToken(String token, ClueRideSessionDto sessionDto) {
         sessionMap.put(token, sessionDto);
+    }
+
+    @Override
+    public ClueRideSessionDto loadSessionForExistingAccount(String accessToken) {
+        requireNonNull(accessToken, "Empty Token. Is this endpoint behind the @Secured annotation?");
+
+        /* Look up what we have in our "cache". */
+        ClueRideSessionDto clueRideSessionDto = getSessionFromToken(accessToken);
+
+        /* Check if we already have a session object for this token ... */
+        if (clueRideSessionDto != null) {
+            return clueRideSessionDto;
+        }
+
+        /* ... if not, create a new one. */
+        clueRideSessionDto = new ClueRideSessionDto();
+
+        ClueRideIdentity clueRideIdentity = accessTokenService.getIdentity(accessToken);
+        clueRideSessionDto.setClueRideIdentity(clueRideIdentity);
+
+        String emailAddressString = addBadgeOsPrincipal(clueRideSessionDto, clueRideIdentity);
+        LOGGER.debug("Instantiating a new Session DTO for {}", emailAddressString);
+
+        Integer memberId = addMember(clueRideSessionDto, clueRideIdentity, emailAddressString);
+
+        if (memberId != null) {
+            addInviteAndOuting(clueRideSessionDto, memberId);
+        }
+
+        setSessionForToken(accessToken, clueRideSessionDto);
+        return clueRideSessionDto;
+    }
+
+    private String addBadgeOsPrincipal(ClueRideSessionDto clueRideSessionDto, ClueRideIdentity clueRideIdentity) {
+        String emailAddressString = clueRideIdentity.getEmail().toString();
+        clueRideSessionDto.setBadgeOSPrincipal(badgeOsPrincipalService.getBadgeOsPrincipal(clueRideIdentity.getEmail()));
+        return emailAddressString;
+    }
+
+    private Integer addMember(ClueRideSessionDto clueRideSessionDto, ClueRideIdentity clueRideIdentity, String emailAddressString) {
+        Integer memberId = null;
+        try {
+            Member member = memberService.getMemberByEmail(clueRideIdentity.getEmail());
+            clueRideSessionDto.setMember(member);
+            memberId = member.getId();
+        } catch (RecordNotFoundException rnfe) {
+            // TODO: CA-409 (maybe throw RuntimeException about data records amiss?)
+            LOGGER.error("Unable to find member record for email: {}", emailAddressString);
+        }
+        return memberId;
+    }
+
+    public void addInviteAndOuting(ClueRideSessionDto clueRideSessionDto, Integer memberId) {
+        List<Invite> invites = inviteService.getMemberInvites(memberId);
+        if (invites.size() > 0) {
+            /* The session only cares about the next one coming up. */
+            Invite invite = invites.get(0);
+            clueRideSessionDto.setInvite(invite);
+
+            /* Check if we can retrieve the Outing. */
+            OutingView outingView = outingService.getViewById(invite.getOutingId());
+            clueRideSessionDto.setOutingView(outingView);
+        }
     }
 
 }

--- a/src/main/java/com/clueride/auth/state/AccessStateService.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateService.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.auth.state;
 
+import com.clueride.domain.account.member.Member;
+
 /**
  * Supports AccessStateWebService REST API.
  */
@@ -37,5 +39,25 @@ public interface AccessStateService {
      * </ul>
      */
     Boolean isRegistered(String authHeader);
+
+    /**
+     * Returns an evaluation of the Account represented by the AuthHeader
+     * -- specifically, an instance of {@link AccountState}.
+     *
+     * @param authHeader Access token representing a given account.
+     * @return Determination of {@link AccountState}.
+     */
+    AccountState getAccountState(String authHeader);
+
+    /**
+     * Upon confirmation of an email address, the client will have an access token which
+     * when validated by the 3rd-party Auth service, allows this service to establish records
+     * for both ClueRide and BadgeOS.
+     *
+     * @param member {@link Member} instance as assembled by the client from JWT token from 3rd-party Auth service.
+     * @param authHeader String representing the raw Authorization header -- expects 'Bearer' style header.
+     * @return the updated Member record including the IDs required (member ID and BadgeOS ID).
+     */
+    Member registerNewMember(Member member, String authHeader);
 
 }

--- a/src/main/java/com/clueride/auth/state/AccessStateWebService.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateWebService.java
@@ -17,15 +17,14 @@
  */
 package com.clueride.auth.state;
 
+import com.clueride.domain.account.member.Member;
+import org.apache.http.HttpHeaders;
+
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-
-import org.apache.http.HttpHeaders;
 
 /**
  * REST API for certain operations on an AccessToken's state.
@@ -34,7 +33,7 @@ import org.apache.http.HttpHeaders;
  *
  * Obtaining an AccessToken is the responsibility of a 3rd-party identity provider.
  */
-@Path("access/state")
+@Path("/access/state")
 @RequestScoped
 public class AccessStateWebService {
     @Inject
@@ -47,6 +46,23 @@ public class AccessStateWebService {
     public Boolean getAccessTokenState() {
         String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
         return accessStateService.isRegistered(authHeader);
+    }
+
+    @GET
+    @Path("account")
+    @Produces(MediaType.APPLICATION_JSON)
+    public AccountState getAccountState() {
+        String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        return accessStateService.getAccountState(authHeader);
+    }
+
+    @POST
+    @Path("init")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Member registerNewMember(Member member) {
+        String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        return accessStateService.registerNewMember(member, authHeader);
     }
 
 }

--- a/src/main/java/com/clueride/auth/state/AccountState.java
+++ b/src/main/java/com/clueride/auth/state/AccountState.java
@@ -1,0 +1,39 @@
+package com.clueride.auth.state;
+
+import com.clueride.domain.account.member.Member;
+
+/**
+ * AccountState summarizes where an Account sits in its life-cycle.
+ *
+ * <ul>
+ *     <li>EXISTING represents the stable existence of an Account with records. It may need
+ *     to renew its access token, but the account itself is well-established with records in both
+ *     this server ({@link Member} records) and BadgeOS.</li>
+ *
+ *     <li>NEW represents an account that has been verified by the 3rd-party Auth tool, and has a
+ *     set of profile data that can be used to prepare both Member and BadgeOS records.</li>
+ *
+ *     <li>TEST represents either an account with the configured Bearer token, or an account
+ *     recognized as a ClueRide Test account. It is given an access token that does not require
+ *     3rd-party validation and can only run on the test instances.</li>
+ *
+ *     <li>INVALID represents an account that cannot be validated for one of several reasons.</li>
+ *
+ *     <li>UNRECOGNIZED represents a token that can't be turned into an account for us to check;
+ *     3rd-party isn't able match token with a principal.</li>
+ *
+ *     <li>ARCHIVED represents the historical records of an inactive user whose records are kept intact
+ *     for the purposes of documenting badge awards.</li>
+ *
+ *     NOTE: A user's account that is deleted does not have a state in this system. Since all records are
+ *     deleted, if the user comes back, they are given a NEW user state.
+ * </ul>
+ */
+public enum AccountState {
+    EXISTING,
+    NEW,
+    TEST,
+    INVALID,
+    UNRECOGNIZED,
+    ARCHIVED
+}

--- a/src/main/java/com/clueride/domain/account/member/Member.java
+++ b/src/main/java/com/clueride/domain/account/member/Member.java
@@ -17,12 +17,12 @@
  */
 package com.clueride.domain.account.member;
 
-import java.io.Serializable;
-import java.util.Collections;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.io.Serializable;
+import java.util.Collections;
 
 public class Member implements Serializable {
     private int id;
@@ -86,6 +86,11 @@ public class Member implements Serializable {
 
     public String getImageUrl() {
         return imageUrl;
+    }
+
+    /** Alias for `emailAddress` supporting JWT profile instance. */
+    public void setEmail(String email) {
+        this.emailAddress = email;
     }
 
     @Override

--- a/src/main/java/com/clueride/domain/account/member/MemberEntity.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberEntity.java
@@ -17,19 +17,13 @@
  */
 package com.clueride.domain.account.member;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-
+import com.clueride.auth.identity.ClueRideIdentity;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import com.clueride.auth.identity.ClueRideIdentity;
+import javax.persistence.*;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -79,6 +73,7 @@ public class MemberEntity {
                 .withId(member.getId())
                 .withBadgeOSId(member.getBadgeOSId())
                 .withPhone(member.getPhoneNumber())
+                .withImageUrl(member.getImageUrl())
                 .withFirstName(member.getFirstName())
                 .withLastName(member.getLastName())
                 .withDisplayName(member.getDisplayName())

--- a/src/main/java/com/clueride/domain/account/member/MemberService.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberService.java
@@ -17,12 +17,11 @@
  */
 package com.clueride.domain.account.member;
 
-import java.util.List;
+import com.clueride.auth.identity.ClueRideIdentity;
 
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-
-import com.clueride.auth.identity.ClueRideIdentity;
+import java.util.List;
 
 /**
  * Provides business-layer services for Clue Ride Members.
@@ -68,7 +67,7 @@ public interface MemberService {
      * @param clueRideIdentity personal data provided by Identity Provider.
      * @return Member instance built from ClueRideIdentity.
      */
-    Member createNewMember(ClueRideIdentity clueRideIdentity);
+    MemberEntity createNewMember(ClueRideIdentity clueRideIdentity);
 
     /**
      * Given a pattern, return a list of members that match the pattern.
@@ -88,8 +87,9 @@ public interface MemberService {
      * </ul>
      *
      * @param member to be checked.
+     * @param authHeader the token which can be confirmed against 3rd-party Auth service.
      * @return Updates for conflicting information, if appropriate.
      */
-    Member crossCheck(Member member);
+    Member crossCheck(Member member, String authHeader);
 
 }

--- a/src/main/java/com/clueride/domain/account/member/MemberWebService.java
+++ b/src/main/java/com/clueride/domain/account/member/MemberWebService.java
@@ -17,19 +17,15 @@
  */
 package com.clueride.domain.account.member;
 
-import java.util.List;
+import com.clueride.auth.Secured;
+import org.apache.http.HttpHeaders;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-
-import com.clueride.auth.Secured;
+import java.util.List;
 
 /**
  * REST API for Members.
@@ -39,6 +35,9 @@ import com.clueride.auth.Secured;
 public class MemberWebService {
     @Inject
     private MemberService memberService;
+
+    @Inject
+    HttpServletRequest httpServletRequest;
 
     @GET
     @Secured
@@ -64,13 +63,12 @@ public class MemberWebService {
     }
 
     @POST
-    @Secured
     @Path("cross-check")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public Member performCrossCheck(Member member) {
-        return memberService.crossCheck(member);
+        String authHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        return memberService.crossCheck(member, authHeader);
     }
-
 
 }

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -19,6 +19,7 @@ package com.clueride.domain.course;
 
 import com.clueride.auth.session.ClueRideSession;
 import com.clueride.auth.session.ClueRideSessionDto;
+import com.clueride.domain.outing.NoSessionOutingException;
 import com.clueride.network.path.PathService;
 
 import javax.enterprise.context.SessionScoped;
@@ -26,6 +27,8 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of CourseService.
@@ -50,6 +53,11 @@ public class CourseServiceImpl implements CourseService {
 
     @Override
     public Course getSessionCourse() {
+        requireNonNull(clueRideSessionDto, "Session not established");
+
+        if (clueRideSessionDto.hasNoOuting()) {
+            throw new NoSessionOutingException();
+        }
         return getById(
                 clueRideSessionDto.getOutingView().getCourseId()
         );

--- a/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/GameStateServiceImpl.java
@@ -26,6 +26,7 @@ import com.clueride.domain.course.CourseService;
 import com.clueride.domain.game.ssevent.SSEventService;
 import com.clueride.domain.location.Location;
 import com.clueride.domain.location.LocationService;
+import com.clueride.domain.outing.NoSessionOutingException;
 import com.clueride.domain.outing.OutingView;
 import com.clueride.domain.puzzle.Puzzle;
 import com.clueride.domain.puzzle.PuzzleService;
@@ -89,8 +90,11 @@ public class GameStateServiceImpl implements GameStateService {
 
     /**
      * Retrieves the GameState by Outing ID.
+     *
      * If other sessions have advanced the GameState, it will be available in our map.
      * If not, we want to set it to an appropriate state.
+     * If there is no Game in progress, or there is no Outing, the Game State should reflect this.
+     *
      * @return the GameState instance for the Outing.
      */
     @Override
@@ -99,6 +103,12 @@ public class GameStateServiceImpl implements GameStateService {
     }
 
     private GameState.Builder getBuilderForSession() {
+        requireNonNull(clueRideSessionDto, "Session has not been established");
+
+        if (clueRideSessionDto.hasNoOuting()) {
+            throw new NoSessionOutingException();
+        }
+
         Integer outingId = clueRideSessionDto.getOutingView().getId();
         /* TODO: What to do if outingId is empty?  CA-330: Exception mapping. */
         if (outingId == null) {

--- a/src/main/java/com/clueride/domain/invite/InviteService.java
+++ b/src/main/java/com/clueride/domain/invite/InviteService.java
@@ -17,10 +17,10 @@
  */
 package com.clueride.domain.invite;
 
+import com.clueride.domain.account.member.Member;
+
 import java.io.IOException;
 import java.util.List;
-
-import com.clueride.domain.account.member.Member;
 
 /**
  * Service supporting the Invite Model which ties together an Outing and a Member.
@@ -47,7 +47,9 @@ public interface InviteService {
      * an Invite.
      * Both the Outing and the Member are validated to make sure we have what
      * is needed.
-     * TODO: Inviting an entire team makes more sense.
+     *
+     * This is useful when a new Member is created just prior to joining an existing Outing.
+     *
      * @param outingId The identifier for the Outing which we're inviting people to attend.
      * @param memberId Unique identifier for the person ({@link Member}) who we invite.
      * @return Fully-populated Invite instance.

--- a/src/main/java/com/clueride/domain/outing/NoSessionOutingException.java
+++ b/src/main/java/com/clueride/domain/outing/NoSessionOutingException.java
@@ -1,0 +1,7 @@
+package com.clueride.domain.outing;
+
+/**
+ * Thrown when an outing is expected, but there isn't one assigned to the Session.
+ */
+public class NoSessionOutingException extends RuntimeException {
+}

--- a/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
+++ b/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
@@ -17,13 +17,12 @@
  */
 package com.clueride.domain.outing;
 
-import javax.enterprise.context.SessionScoped;
-import javax.inject.Inject;
-
-import org.slf4j.Logger;
-
 import com.clueride.auth.session.ClueRideSession;
 import com.clueride.auth.session.ClueRideSessionDto;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
 
 /**
  * Implementation of OutingService.
@@ -54,6 +53,9 @@ public class OutingServiceImpl implements OutingService {
 
     @Override
     public OutingView getActiveOutingView() {
+        if (clueRideSessionDto.hasNoOuting()) {
+            throw new NoSessionOutingException();
+        }
         return clueRideSessionDto.getOutingView();
     }
 


### PR DESCRIPTION
- Adds endpoint for setting up a new accounts under AccessStateService.
- Endpoint service also prepares the Session DTO.
- Moves validation of the Access Token under that service.
- Refactors Session Producer functionality under the service rather than the provider.
- Adds alias for Member/Profile property to set the Email (EmailAddress is main attribute).
- Image URL was not quite handled for MemberEntity.
- MemberService now returns Entity to allow mutation with BadgeOS ID.

Toward endpoint robustness (for future):
- Adds convenience method to Session DTO to tell if there is an outing assigned to the session.
- New Runtime Exceptions for improved reporting.
- The `cross-check` endpoint had been intended to handle creation and updates to accounts, but this should be used only for updates in the future. (Design is not fully developed).