### PR TITLE
SVR-126 Support selecting the next course to use as a "default"

### DIFF
--- a/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
@@ -31,8 +31,8 @@ import com.clueride.domain.account.member.MemberEntity;
 import com.clueride.domain.account.member.MemberService;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.account.principal.BadgeOsPrincipalService;
-import com.clueride.domain.account.register.RegisterService;
 import com.clueride.domain.invite.InviteService;
+import com.clueride.domain.outing.OutingConstants;
 import com.clueride.domain.outing.OutingService;
 import org.slf4j.Logger;
 
@@ -56,7 +56,6 @@ public class AccessStateServiceImpl implements AccessStateService {
     private final ClueRideSessionService clueRideSessionService;
     private final InviteService inviteService;
     private final BadgeOsUserService badgeOsUserService;
-    private final RegisterService registerService;
 
     @Inject
     public AccessStateServiceImpl(
@@ -67,8 +66,7 @@ public class AccessStateServiceImpl implements AccessStateService {
             OutingService outingService,
             ClueRideSessionService clueRideSessionService,
             InviteService inviteService,
-            BadgeOsUserService badgeOsUserService,
-            RegisterService registerService
+            BadgeOsUserService badgeOsUserService
     ) {
         this.accessTokenService = accessTokenService;
         this.configService = configService;
@@ -78,7 +76,6 @@ public class AccessStateServiceImpl implements AccessStateService {
         this.clueRideSessionService = clueRideSessionService;
         this.inviteService = inviteService;
         this.badgeOsUserService = badgeOsUserService;
-        this.registerService = registerService;
     }
 
     @Override
@@ -205,10 +202,9 @@ public class AccessStateServiceImpl implements AccessStateService {
     }
 
     private void addEternalInvite(ClueRideIdentity clueRideIdentity, MemberEntity memberEntity, ClueRideSessionDto clueRideSessionDto) {
-        final int ETERNAL_OUTING = 1;
         try {
             clueRideSessionDto.setInvite(
-                    inviteService.createNew(ETERNAL_OUTING, memberEntity.getId())
+                    inviteService.createNew(OutingConstants.ETERNAL_OUTING_ID, memberEntity.getId())
             );
         } catch (IOException e) {
             e.printStackTrace();
@@ -217,7 +213,7 @@ public class AccessStateServiceImpl implements AccessStateService {
         clueRideSessionDto.setMember(memberEntity.build());
         clueRideSessionDto.setClueRideIdentity(clueRideIdentity);
         clueRideSessionDto.setOutingView(
-                outingService.getViewById(ETERNAL_OUTING)
+                outingService.getViewById(OutingConstants.ETERNAL_OUTING_ID)
         );
     }
 
@@ -267,9 +263,8 @@ public class AccessStateServiceImpl implements AccessStateService {
 
         // TODO: CA-409 connect new identities with updated records & test coverage.
         /* Check to see if we have a Member Record. */
-        Member member = null;
         try {
-            member = memberService.getMemberByEmail(emailAddress);
+            memberService.getMemberByEmail(emailAddress);
         } catch (RecordNotFoundException rnfe) {
             /* No existing Member record, let's create one from ClueRideIdentity. */
             memberService.createNewMember(clueRideIdentity);

--- a/src/main/java/com/clueride/domain/course/CourseService.java
+++ b/src/main/java/com/clueride/domain/course/CourseService.java
@@ -71,4 +71,15 @@ public interface CourseService {
      * @return pretty much the same as what was passed in.
      */
     Course updateCourse(CourseEntity courseEntity);
+
+    /**
+     * Given an existing course, make it the default course for new Outings.
+     *
+     * This resets the Game State if the course is already the Default.
+     *
+     * @param courseEntity instance of the Course to reset; the ID is sufficient.
+     * @return the same instance.
+     */
+    Course makeDefault(CourseEntity courseEntity);
+
 }

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -20,6 +20,7 @@ package com.clueride.domain.course;
 import com.clueride.auth.session.ClueRideSession;
 import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.outing.NoSessionOutingException;
+import com.clueride.domain.outing.OutingService;
 import com.clueride.network.path.PathService;
 import org.slf4j.Logger;
 
@@ -41,6 +42,7 @@ public class CourseServiceImpl implements CourseService {
 
     private final PathService pathService;
     private final CourseStore courseStore;
+    private final OutingService outingService;
 
     @Inject
     @SessionScoped
@@ -50,10 +52,12 @@ public class CourseServiceImpl implements CourseService {
     @Inject
     public CourseServiceImpl(
             PathService pathService,
-            CourseStore courseStore
-    ) {
+            CourseStore courseStore,
+            OutingService outingService
+            ) {
         this.pathService = pathService;
         this.courseStore = courseStore;
+        this.outingService = outingService;
     }
 
     @Override
@@ -93,6 +97,13 @@ public class CourseServiceImpl implements CourseService {
         LOGGER.debug("Updating {}", courseEntity.getName());
         prepareCourseAttractionsForUpdate(courseEntity);
         courseStore.update(courseEntity);
+        return courseEntity.build();
+    }
+
+    @Override
+    public Course makeDefault(CourseEntity courseEntity) {
+        LOGGER.debug("Setting Course {} to be the Default", courseEntity.getName());
+        outingService.setCourseForEternalOuting(courseEntity.getId());
         return courseEntity.build();
     }
 

--- a/src/main/java/com/clueride/domain/course/CourseWebService.java
+++ b/src/main/java/com/clueride/domain/course/CourseWebService.java
@@ -65,6 +65,16 @@ public class CourseWebService {
 
     @POST
     @Secured
+    @Path("default")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Course makeDefault(CourseEntity courseEntity) {
+        return courseService.makeDefault(courseEntity);
+    }
+
+
+    @POST
+    @Secured
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Course updateCourse(CourseEntity courseEntity) {

--- a/src/main/java/com/clueride/domain/outing/Outing.java
+++ b/src/main/java/com/clueride/domain/outing/Outing.java
@@ -17,10 +17,10 @@
  */
 package com.clueride.domain.outing;
 
-import java.util.Date;
-
 import com.clueride.domain.course.Course;
 import com.clueride.domain.team.Team;
+
+import java.util.Date;
 
 /**
  * Model for the Outing: a particular {@link Team} running a particular {@link Course}
@@ -34,6 +34,14 @@ public class Outing {
     private Integer guideMemberId;
 
     Outing(OutingViewEntity builder) {
+        this.id = builder.getId();
+        this.teamId = builder.getTeamId();
+        this.courseId = builder.getCourseId();
+        this.scheduledTime = builder.getScheduledTime();
+        this.guideMemberId = builder.getGuideMemberId();
+    }
+
+    Outing(OutingEntity builder) {
         this.id = builder.getId();
         this.teamId = builder.getTeamId();
         this.courseId = builder.getCourseId();

--- a/src/main/java/com/clueride/domain/outing/OutingConstants.java
+++ b/src/main/java/com/clueride/domain/outing/OutingConstants.java
@@ -1,0 +1,6 @@
+package com.clueride.domain.outing;
+
+public class OutingConstants {
+    /* This needs to be the ID of the Eternal Outing record in the Database. */
+    public final static int ETERNAL_OUTING_ID = 1;
+}

--- a/src/main/java/com/clueride/domain/outing/OutingEntity.java
+++ b/src/main/java/com/clueride/domain/outing/OutingEntity.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/24/20.
+ */
+package com.clueride.domain.outing;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+/**
+ * Persistable Entity for {@link Outing} instances.
+ */
+@Entity
+@Table(name = "outing")
+public class OutingEntity {
+    @Id
+    private Integer id;
+
+    @Column(name = "scheduled_time") private Date scheduledTime;
+    @Column(name = "course_id") private Integer courseId;
+    @Column(name = "guide_id") private Integer guideMemberId;
+    @Column(name = "team_id") private Integer teamId;
+
+    public OutingEntity() {}
+
+    public static OutingEntity builder() {
+        return new OutingEntity();
+    }
+
+    public Outing build() {
+        return new Outing(this);
+    }
+
+    public static OutingEntity from(Outing instance) {
+        return builder()
+                .withId(instance.getId())
+                .withCourseId(instance.getCourseId())
+                .withTeamId(instance.getTeamId())
+                .withScheduledTime(instance.getScheduledTime())
+                .withGuideMemberId(instance.getGuideMemberId())
+                ;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public OutingEntity withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Date getScheduledTime() {
+        return scheduledTime;
+    }
+
+    public OutingEntity withScheduledTime(Date scheduledTime) {
+        this.scheduledTime = scheduledTime;
+        return this;
+    }
+
+    public Integer getCourseId() {
+        return courseId;
+    }
+
+    public OutingEntity withCourseId(Integer courseId) {
+        this.courseId = courseId;
+        return this;
+    }
+
+    public OutingEntity withTeamId(Integer teamId) {
+        this.teamId = teamId;
+        return this;
+    }
+
+    public Integer getGuideMemberId() {
+        return guideMemberId;
+    }
+
+    public OutingEntity withGuideMemberId(Integer guideMemberId) {
+        this.guideMemberId = guideMemberId;
+        return this;
+    }
+
+    public Integer getTeamId() {
+        return teamId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/src/main/java/com/clueride/domain/outing/OutingService.java
+++ b/src/main/java/com/clueride/domain/outing/OutingService.java
@@ -42,4 +42,12 @@ public interface OutingService {
      */
     OutingView getActiveOutingView();
 
+    /**
+     * Given a Course ID, make the Eternal Outing use that Course.
+     *
+     * @param courseId Course to use as the "default" course for the eternal outing.
+     * @return Updated instance of the OutingView.
+     */
+    OutingView setCourseForEternalOuting(Integer courseId);
+
 }

--- a/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
+++ b/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
@@ -59,4 +59,9 @@ public class OutingServiceImpl implements OutingService {
         return clueRideSessionDto.getOutingView();
     }
 
+    @Override
+    public OutingView setCourseForEternalOuting(Integer courseId) {
+        return outingStore.setCourseForEternalOuting(courseId).build();
+    }
+
 }

--- a/src/main/java/com/clueride/domain/outing/OutingStore.java
+++ b/src/main/java/com/clueride/domain/outing/OutingStore.java
@@ -46,4 +46,9 @@ public interface OutingStore {
      */
     OutingViewEntity getOutingViewById(Integer outingId);
 
+    /**
+     * Given a Course ID, make the Eternal Outing use that Course.
+     */
+    OutingViewEntity setCourseForEternalOuting(Integer courseId);
+
 }


### PR DESCRIPTION
- Adds new API endpoint to set the default course for the Eternal Outing.
- Adds new method to the OutingService
- Adds new OutingEntity to work with just the table and not the full view (we need to persist records here).
- Adds new method to the OutingStore to perform the update.

Also raises the Eternal Outing to Constant status.