### PR TITLE
SVR-130 REST API for path/meta call can get the attraction list all m…

### DIFF
--- a/src/main/java/com/clueride/domain/course/CourseEntity.java
+++ b/src/main/java/com/clueride/domain/course/CourseEntity.java
@@ -48,7 +48,7 @@ public class CourseEntity {
     @Column(name="starting_location_id")
     private Integer startingAttractionId;
 
-    @Transient  /* From the CourseToPathBuilders. */
+    @Transient  /* From the CourseToPathEntities. */
     private List<Integer> pathIds;
 
     @Transient

--- a/src/main/java/com/clueride/domain/course/link/CourseToPathLinkStore.java
+++ b/src/main/java/com/clueride/domain/course/link/CourseToPathLinkStore.java
@@ -20,4 +20,9 @@ public interface CourseToPathLinkStore {
      */
     void remove(CourseToPathLinkEntity courseToPathLinkEntity);
 
+    /**
+     * Removes all links between a Course and its Paths; we're building a complete new set.
+     * @param courseId unique identifier for the Course we're working on.
+     */
+    void dropAllForCourse(Integer courseId);
 }

--- a/src/main/java/com/clueride/domain/course/link/CourseToPathLinkStoreJpa.java
+++ b/src/main/java/com/clueride/domain/course/link/CourseToPathLinkStoreJpa.java
@@ -48,4 +48,23 @@ public class CourseToPathLinkStoreJpa implements CourseToPathLinkStore {
         }
     }
 
+    @Override
+    public void dropAllForCourse(Integer courseId) {
+        try {
+            userTransaction.begin();
+            entityManager.createQuery("delete from CourseToPathLinkEntity where course.id = :courseId")
+                    .setParameter("courseId", courseId)
+                    .executeUpdate();
+            userTransaction.commit();
+        } catch (
+                NotSupportedException |
+                        SystemException |
+                        RollbackException |
+                        HeuristicMixedException |
+                        HeuristicRollbackException e
+        ) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/main/java/com/clueride/domain/path/PathService.java
+++ b/src/main/java/com/clueride/domain/path/PathService.java
@@ -18,6 +18,9 @@
 package com.clueride.domain.path;
 
 import com.clueride.domain.course.Course;
+import com.clueride.domain.course.CourseEntity;
+import com.clueride.domain.course.link.CourseToPathLinkEntity;
+import com.clueride.domain.location.Location;
 import com.clueride.domain.path.meta.PathMeta;
 
 import java.util.List;
@@ -40,6 +43,14 @@ public interface PathService {
     List<Path> getAll();
 
     /**
+     * Retrieves the ordered list of {@link Location} IDs for the course identified
+     * by the courseId.
+     * @param courseId unique identifier for the {@link Course}.
+     * @return Ordered list of the Location IDs for the Course.
+     */
+    List<Integer> getLocationIds(Integer courseId);
+
+    /**
      * When building a Course, lists of Attractions are turned into
      * a list of Path Meta information linking those Attractions.
      *
@@ -54,4 +65,12 @@ public interface PathService {
      */
     List<PathMeta> getPathMetaForAttractions(Integer courseId, List<Integer> attractionIds);
 
+    /**
+     * When persisting a Course, lists of Attractions are turned into
+     * a list of CourseToPathLink records linking Paths to the Course.
+     *
+     * @param courseEntity course possessing the list of Attractions.
+     * @return List of ordered {@link CourseToPathLinkEntity} instances from the Attractions.
+     */
+    List<CourseToPathLinkEntity> getCourseToPathLinkEntities(CourseEntity courseEntity);
 }

--- a/src/main/java/com/clueride/domain/path/attractions/CoursePathAttractionsEntity.java
+++ b/src/main/java/com/clueride/domain/path/attractions/CoursePathAttractionsEntity.java
@@ -32,6 +32,7 @@ import javax.persistence.Table;
  * without Geometry for a Course and its locations.
  *
  * This is a read-only entity because it is backed by a view.
+ * However, it provides setters for the purposes of testing.
  *
  * This class is used to tie together the IDs, but not necessarily
  * the actual entities behind those IDs. It's the responsibility of
@@ -57,12 +58,21 @@ public class CoursePathAttractionsEntity {
     @Column(name="end_attraction_id")
     private Integer endAttractionId;
 
+    public static CoursePathAttractionsEntity builder() {
+        return new CoursePathAttractionsEntity();
+    }
+
     public static PathMetaEntity from(CoursePathAttractionsEntity existingPath) {
         return PathMetaEntity.builder()
                 .withId(existingPath.pathId)
                 .withCourseToPathId(existingPath.id)
                 .withStartAttractionId(existingPath.startAttractionId)
                 .withEndAttractionId(existingPath.endAttractionId);
+    }
+
+    public CoursePathAttractionsEntity withId(Integer id) {
+        this.id = id;
+        return this;
     }
 
     public CoursePathAttractions build() {
@@ -89,6 +99,11 @@ public class CoursePathAttractionsEntity {
         this.pathOrder = pathOrder;
     }
 
+    public CoursePathAttractionsEntity withPathOrder(Integer pathOrder) {
+        this.pathOrder = pathOrder;
+        return this;
+    }
+
     public Integer getStartNodeId() {
         return startNodeId;
     }
@@ -113,8 +128,18 @@ public class CoursePathAttractionsEntity {
         this.courseId = courseId;
     }
 
+    public CoursePathAttractionsEntity withCourseId(Integer courseId) {
+        this.courseId = courseId;
+        return this;
+    }
+
     public void setPathId(Integer pathId) {
         this.pathId = pathId;
+    }
+
+    public CoursePathAttractionsEntity withPathId(Integer pathId) {
+        this.pathId = pathId;
+        return this;
     }
 
     public void setStartNodeId(Integer startNodeId) {
@@ -129,8 +154,18 @@ public class CoursePathAttractionsEntity {
         this.startAttractionId = startAttractionId;
     }
 
+    public CoursePathAttractionsEntity withStartAttractionId(Integer startAttractionId) {
+        this.startAttractionId = startAttractionId;
+        return this;
+    }
+
     public void setEndAttractionId(Integer endAttractionId) {
         this.endAttractionId = endAttractionId;
+    }
+
+    public CoursePathAttractionsEntity withEndAttractionId(Integer endAttractionId) {
+        this.endAttractionId = endAttractionId;
+        return this;
     }
 
     @Override

--- a/src/main/java/com/clueride/domain/path/meta/PathMetaEntity.java
+++ b/src/main/java/com/clueride/domain/path/meta/PathMetaEntity.java
@@ -16,6 +16,9 @@ public class PathMetaEntity {
     @Column(name="end_node_id")
     private Integer endNodeId;
 
+    @Column(name="name")
+    private String name;
+
     @Transient
     private Integer courseToPathId;
 
@@ -42,6 +45,15 @@ public class PathMetaEntity {
 
     public PathMetaEntity withId(Integer id) {
         this.id = id;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PathMetaEntity withName(String name) {
+        this.name = name;
         return this;
     }
 

--- a/src/main/java/com/clueride/domain/path/meta/PathMetaStore.java
+++ b/src/main/java/com/clueride/domain/path/meta/PathMetaStore.java
@@ -25,14 +25,15 @@ public interface PathMetaStore {
     PathMetaEntity createNew(PathMetaEntity pathMetaEntity);
 
     /**
-     * Finds a Path that links between a pair of AttractionIDs.
+     * Finds a Path that links between a pair of Node IDs.
      *
-     * The direction is significant (but should it be?).
+     * The direction is significant because the Edge may be different
+     * depending on the direction of travel (one-way streets and uphills).
      *
-     * @param startId  Starting Attraction ID.
-     * @param endId Ending Attraction ID.
+     * @param startNodeId  Starting Node ID.
+     * @param endNodeId Ending Node ID.
      * @return First matching PathMeta record.
      */
-    PathMetaEntity findSuitablePath(Integer startId, Integer endId);
+    PathMetaEntity findSuitablePath(Integer startNodeId, Integer endNodeId);
 
 }

--- a/src/main/java/com/clueride/domain/path/meta/PathMetaStoreJpa.java
+++ b/src/main/java/com/clueride/domain/path/meta/PathMetaStoreJpa.java
@@ -36,8 +36,13 @@ public class PathMetaStoreJpa implements PathMetaStore {
     }
 
     @Override
-    public PathMetaEntity findSuitablePath(Integer startId, Integer endId) {
-        return null;
+    public PathMetaEntity findSuitablePath(Integer startNodeId, Integer endNodeId) {
+        return entityManager.createQuery("SELECT p from PathMetaEntity p " +
+                "where startNodeId = :startNodeId " +
+                "  and endNodeId = :endNodeId", PathMetaEntity.class)
+                .setParameter("startNodeId", startNodeId)
+                .setParameter("endNodeId", endNodeId)
+                .getSingleResult();
     }
 
 }

--- a/src/main/java/com/clueride/domain/path/meta/README.md
+++ b/src/main/java/com/clueride/domain/path/meta/README.md
@@ -12,6 +12,6 @@ sorted out.
   
 # Collaborators
 
-* CourseToPath is the relationship between Path and Course and holds 
+* CourseToPathLink is the relationship between Path and Course and holds 
 the order for the Course.
 * PathGeometryEntity holds the GeoSpatial info for placement on the map.

--- a/src/main/java/com/clueride/network/path/PathService.java
+++ b/src/main/java/com/clueride/network/path/PathService.java
@@ -17,10 +17,6 @@
  */
 package com.clueride.network.path;
 
-import java.util.List;
-
-import com.clueride.domain.course.Course;
-import com.clueride.domain.location.Location;
 import com.clueride.domain.path.Path;
 
 /**
@@ -33,18 +29,10 @@ public interface PathService {
      * by the pathId.
      *
      * A Path is an ordered sequence of Edge instances.
-     * @param pathId
+     * @param pathId unique identifier for the Path.
      * @return String formatted as a GeoJSON feature collection containing
      * the Geometry for an ordered array of LineString.
      */
     String getPathGeoJsonById(Integer pathId);
-
-    /**
-     * Retrieves the ordered list of {@link Location} IDs for the course identified
-     * by the courseId.
-     * @param courseId unique identifier for the {@link Course}.
-     * @return Ordered list of the Location IDs for the Course.
-     */
-    List<Integer> getLocationIds(Integer courseId);
 
 }

--- a/src/main/java/com/clueride/network/path/PathServiceImpl.java
+++ b/src/main/java/com/clueride/network/path/PathServiceImpl.java
@@ -17,14 +17,7 @@
  */
 package com.clueride.network.path;
 
-import com.clueride.domain.path.attractions.CoursePathAttractionsEntity;
-import com.clueride.domain.path.attractions.CoursePathAttractionsStore;
-import org.slf4j.Logger;
-
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,40 +25,14 @@ import static java.util.Objects.requireNonNull;
  * Default implementation of {@link PathService}.
  */
 public class PathServiceImpl implements PathService {
-    @Inject
-    private Logger LOGGER;
 
     @Inject
     private PathStore pathStore;
-
-    @Inject
-    private CoursePathAttractionsStore coursePathAttractionsStore;
 
     @Override
     public String getPathGeoJsonById(Integer pathId) {
         requireNonNull(pathId, "Path ID must be provided");
         return pathStore.getPathGeoJson(pathId);
-    }
-
-    @Override
-    public List<Integer> getLocationIds(Integer courseId) {
-        requireNonNull(courseId, "Course ID must be provided");
-
-        List<CoursePathAttractionsEntity> paths = coursePathAttractionsStore.getPathAttractionsForCourse(courseId);
-        if (paths.size() == 0) {
-            LOGGER.warn("No paths found for course ID {}", courseId );
-            return Collections.emptyList();
-        }
-
-        List<Integer> locationIds = new ArrayList<>();
-        CoursePathAttractionsEntity lastBuilder = null;
-        for (CoursePathAttractionsEntity builder : paths) {
-            locationIds.add(builder.getStartLocationId());
-            lastBuilder = builder;
-        }
-        locationIds.add(lastBuilder.getEndLocationId());
-
-        return locationIds;
     }
 
 }

--- a/src/test/java/com/clueride/domain/path/PathServiceImplTest.java
+++ b/src/test/java/com/clueride/domain/path/PathServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.clueride.domain.path;
+
+import com.clueride.domain.attraction.AttractionEntity;
+import com.clueride.domain.attraction.AttractionStore;
+import com.clueride.domain.course.CourseEntity;
+import com.clueride.domain.course.CourseStore;
+import com.clueride.domain.course.link.CourseToPathLinkStore;
+import com.clueride.domain.path.attractions.CoursePathAttractionsEntity;
+import com.clueride.domain.path.attractions.CoursePathAttractionsStore;
+import com.clueride.domain.path.meta.PathMeta;
+import com.clueride.domain.path.meta.PathMetaEntity;
+import com.clueride.domain.path.meta.PathMetaStore;
+import com.clueride.network.path.PathStore;
+import org.jglue.cdiunit.NgCdiRunner;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class PathServiceImplTest extends NgCdiRunner {
+    private final static Integer COURSE_ID = 6;
+    private final static Integer NODE_ID_1 = 901;
+    private final static Integer NODE_ID_2 = 902;
+    private final static Integer NODE_ID_3 = 903;
+    private final static Integer ATTR_ID_1 = 1;
+    private final static Integer ATTR_ID_2 = 2;
+    private final static Integer ATTR_ID_3 = 3;
+    private final static Integer ATTR_ID_4 = 4;
+    private final List<Integer> attractionIds = Arrays.asList(
+            ATTR_ID_1,
+            ATTR_ID_2,
+            ATTR_ID_3
+    );
+    private final static Integer PATH_ID_1 = 101;
+    private final static Integer PATH_ID_2 = 102;
+    private final static Integer PATH_ID_EXTRA = 1001;
+    private final static CoursePathAttractionsEntity PATH_1 =
+            CoursePathAttractionsEntity.builder()
+                    .withPathId(PATH_ID_1)
+                    .withCourseId(COURSE_ID)
+                    .withStartAttractionId(ATTR_ID_1)
+                    .withEndAttractionId(ATTR_ID_2);
+    private final static CoursePathAttractionsEntity PATH_2 =
+            CoursePathAttractionsEntity.builder()
+                    .withPathId(PATH_ID_2)
+                    .withCourseId(COURSE_ID)
+                    .withStartAttractionId(ATTR_ID_2)
+                    .withEndAttractionId(ATTR_ID_3);
+    private final static CoursePathAttractionsEntity PATH_EXTRA =
+            CoursePathAttractionsEntity.builder()
+                    .withPathId(PATH_ID_EXTRA)
+                    .withCourseId(COURSE_ID)
+                    .withStartAttractionId(ATTR_ID_3)
+                    .withEndAttractionId(ATTR_ID_4);
+
+    @Mock
+    private Logger LOGGER;
+
+    @Mock
+    private CourseStore courseStore;
+
+    @Mock
+    private CoursePathAttractionsStore coursePathAttractionsStore;
+
+    @Mock
+    private PathStore pathStore;
+
+    @Mock
+    private PathMetaStore pathMetaStore;
+
+    @Mock
+    private AttractionStore attractionStore;
+
+    @Mock
+    private CourseToPathLinkStore courseToPathLinkStore;
+
+    @InjectMocks
+    private PathServiceImpl toTest;
+
+    @BeforeMethod
+    public void setUp() {
+        initMocks(this);
+        assertNotNull(toTest);
+    }
+
+    @Test
+    public void testGetPathMetaForAttractions_removeExtra() {
+        /* Train Mocks */
+        for (int attractionId : attractionIds) {
+            when(attractionStore.getById(attractionId)).thenReturn(
+                    AttractionEntity.builder()
+                            .withId(attractionId)
+                            .withNodeId(attractionId + 900)
+            );
+        }
+        when(courseStore.getCourseById(COURSE_ID)).thenReturn(CourseEntity.builder().withId(COURSE_ID));
+        when(coursePathAttractionsStore.getPathAttractionsForCourse(COURSE_ID)).thenReturn(
+                Arrays.asList(PATH_1, PATH_2, PATH_EXTRA)
+        );
+        when(pathMetaStore.findSuitablePath(NODE_ID_1, NODE_ID_2)).thenReturn(
+                PathMetaEntity.builder()
+        );
+        when(pathMetaStore.findSuitablePath(NODE_ID_2, NODE_ID_3)).thenReturn(
+                PathMetaEntity.builder()
+        );
+
+        /* Make Call */
+        List<PathMeta> actual = toTest.getPathMetaForAttractions(
+                COURSE_ID,
+                attractionIds
+        );
+
+        /* Verify */
+        assertNotNull(actual);
+        assertEquals(actual.size(), attractionIds.size() - 1);
+        verify(pathMetaStore, times(0)).createNew(any());
+        verify(courseToPathLinkStore, times(0)).remove(any());
+    }
+
+}


### PR DESCRIPTION
…essed up

- Changes approach for persisting Paths for a given set of Attractions and the links to those Paths from a Course.

This simplifies how the records are managed: Paths are created for pairs of Attractions just so the presence or absence of Edge
records can be checked. Once the Course is saved, the resulting list of settled Paths is then linked to the Course by
clearing out existing Link records and replacing with a new full set.

Adding constraint criteria to the DB records greatly helped in narrowing down where the issues were arising in the code.