### PR TITLE
SVR-127 Support resetting the Game State

### DIFF
--- a/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionDto.java
@@ -21,7 +21,7 @@ import com.clueride.auth.identity.ClueRideIdentity;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.invite.Invite;
-import com.clueride.domain.outing.OutingView;
+import com.clueride.domain.outing.OutingConstants;
 import com.clueride.domain.puzzle.state.PuzzleState;
 
 import java.io.Serializable;
@@ -34,8 +34,8 @@ public class ClueRideSessionDto implements Serializable {
     private BadgeOsPrincipal badgeOsPrincipal = null;
     private Member member = null;
     private Invite invite = null;
-    private OutingView outingView = null;
     private PuzzleState puzzleState = null;
+    private Integer outingId = OutingConstants.NO_OUTING;
 
     public void setClueRideIdentity(ClueRideIdentity clueRideIdentity) {
         this.clueRideIdentity = clueRideIdentity;
@@ -69,14 +69,6 @@ public class ClueRideSessionDto implements Serializable {
         this.invite = invite;
     }
 
-    public OutingView getOutingView() {
-        return outingView;
-    }
-
-    public void setOutingView(OutingView outingView) {
-        this.outingView = outingView;
-    }
-
     public void setPuzzleState(PuzzleState puzzleState) {
         this.puzzleState = puzzleState;
     }
@@ -85,9 +77,17 @@ public class ClueRideSessionDto implements Serializable {
         return puzzleState;
     }
 
+    public Integer getOutingId() {
+        return outingId;
+    }
+
+    public void setOutingId(Integer outingId) {
+        this.outingId = outingId;
+    }
+
     /** Convenience method. */
     public boolean hasNoOuting() {
-        return (this.outingView == null);
+        return (this.outingId == OutingConstants.NO_OUTING);
     }
 
 }

--- a/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
+++ b/src/main/java/com/clueride/auth/session/ClueRideSessionServiceImpl.java
@@ -130,8 +130,9 @@ public class ClueRideSessionServiceImpl implements ClueRideSessionService {
             clueRideSessionDto.setInvite(invite);
 
             /* Check if we can retrieve the Outing. */
+            // TODO: What happens if there isn't an outing with that ID?
             OutingView outingView = outingService.getViewById(invite.getOutingId());
-            clueRideSessionDto.setOutingView(outingView);
+            clueRideSessionDto.setOutingId(outingView.getId());
         }
     }
 

--- a/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
+++ b/src/main/java/com/clueride/auth/state/AccessStateServiceImpl.java
@@ -33,7 +33,6 @@ import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.account.principal.BadgeOsPrincipalService;
 import com.clueride.domain.invite.InviteService;
 import com.clueride.domain.outing.OutingConstants;
-import com.clueride.domain.outing.OutingService;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
@@ -52,7 +51,6 @@ public class AccessStateServiceImpl implements AccessStateService {
     private final ConfigService configService;
     private final BadgeOsPrincipalService badgeOsPrincipalService;
     private final MemberService memberService;
-    private final OutingService outingService;
     private final ClueRideSessionService clueRideSessionService;
     private final InviteService inviteService;
     private final BadgeOsUserService badgeOsUserService;
@@ -63,7 +61,6 @@ public class AccessStateServiceImpl implements AccessStateService {
             ConfigService configService,
             BadgeOsPrincipalService badgeOsPrincipalService,
             MemberService memberService,
-            OutingService outingService,
             ClueRideSessionService clueRideSessionService,
             InviteService inviteService,
             BadgeOsUserService badgeOsUserService
@@ -72,7 +69,6 @@ public class AccessStateServiceImpl implements AccessStateService {
         this.configService = configService;
         this.badgeOsPrincipalService = badgeOsPrincipalService;
         this.memberService = memberService;
-        this.outingService = outingService;
         this.clueRideSessionService = clueRideSessionService;
         this.inviteService = inviteService;
         this.badgeOsUserService = badgeOsUserService;
@@ -212,9 +208,7 @@ public class AccessStateServiceImpl implements AccessStateService {
 
         clueRideSessionDto.setMember(memberEntity.build());
         clueRideSessionDto.setClueRideIdentity(clueRideIdentity);
-        clueRideSessionDto.setOutingView(
-                outingService.getViewById(OutingConstants.ETERNAL_OUTING_ID)
-        );
+        clueRideSessionDto.setOutingId(OutingConstants.ETERNAL_OUTING_ID);
     }
 
     /**

--- a/src/main/java/com/clueride/domain/course/CourseService.java
+++ b/src/main/java/com/clueride/domain/course/CourseService.java
@@ -77,9 +77,9 @@ public interface CourseService {
      *
      * This resets the Game State if the course is already the Default.
      *
-     * @param courseEntity instance of the Course to reset; the ID is sufficient.
+     * @param courseId unique identifier for the Course to serve as the Default.
      * @return the same instance.
      */
-    Course makeDefault(CourseEntity courseEntity);
+    Course makeDefault(Integer courseId);
 
 }

--- a/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
+++ b/src/main/java/com/clueride/domain/course/CourseServiceImpl.java
@@ -69,7 +69,9 @@ public class CourseServiceImpl implements CourseService {
             throw new NoSessionOutingException();
         }
         return getById(
-                clueRideSessionDto.getOutingView().getCourseId()
+                outingService.getViewById(
+                        clueRideSessionDto.getOutingId()
+                ).getCourseId()
         );
     }
 
@@ -102,9 +104,10 @@ public class CourseServiceImpl implements CourseService {
     }
 
     @Override
-    public Course makeDefault(CourseEntity courseEntity) {
+    public Course makeDefault(Integer courseId) {
+        CourseEntity courseEntity = courseStore.getCourseById(courseId);
         LOGGER.debug("Setting Course {} to be the Default", courseEntity.getName());
-        outingService.setCourseForEternalOuting(courseEntity.getId());
+        outingService.setCourseForEternalOuting(courseId);
         return courseEntity.build();
     }
 

--- a/src/main/java/com/clueride/domain/course/CourseWebService.java
+++ b/src/main/java/com/clueride/domain/course/CourseWebService.java
@@ -65,16 +65,6 @@ public class CourseWebService {
 
     @POST
     @Secured
-    @Path("default")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public Course makeDefault(CourseEntity courseEntity) {
-        return courseService.makeDefault(courseEntity);
-    }
-
-
-    @POST
-    @Secured
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Course updateCourse(CourseEntity courseEntity) {

--- a/src/main/java/com/clueride/domain/game/GameStateService.java
+++ b/src/main/java/com/clueride/domain/game/GameStateService.java
@@ -72,4 +72,24 @@ public interface GameStateService {
      */
     AnswerSummary postAnswer(AnswerPost answerPost);
 
+    /**
+     * During testing, a reset of the Game State is better than restarting the server.
+     *
+     * This can be called via REST API or whenever the Eternal Outing has a new default Course and
+     * the previous state for the Outing requires a reset.
+     *
+     * @param outingId identifier for the Outing.
+     * @return the Game State reset for the Eternal Outing.
+     */
+    GameState resetGameState(Integer outingId);
+
+    GameState resetDefaultOutingGameState();
+
+    /**
+     * During testing, when changing the default Course, we want the GameState to know about the changes.
+     *
+     * @param courseId unique identifier for the course we want to provide as the default.
+     * @return Updated (and reset) GameState.
+     */
+    GameState updateDefaultCourse(Integer courseId);
 }

--- a/src/main/java/com/clueride/domain/game/GameStateWebService.java
+++ b/src/main/java/com/clueride/domain/game/GameStateWebService.java
@@ -17,20 +17,17 @@
  */
 package com.clueride.domain.game;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import com.clueride.auth.Secured;
+import com.clueride.domain.course.CourseEntity;
+
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 
 /**
  * REST API for Game State.
  */
-@Path("game-state")
+@Path("/game-state")
 public class GameStateWebService {
 
     @Inject
@@ -68,6 +65,23 @@ public class GameStateWebService {
     @Path("departure")
     public GameState updateOutingWithDeparture() {
         return gameStateService.updateOutingStateWithDeparture();
+    }
+
+    @DELETE
+    @Secured
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public GameState resetActiveSessionGameState() {
+        return gameStateService.resetDefaultOutingGameState();
+    }
+
+    @POST
+    @Secured
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("default-course")
+    public GameState updateDefaultCourse(CourseEntity courseEntity) {
+        return gameStateService.updateDefaultCourse(courseEntity.getId());
     }
 
 }

--- a/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
+++ b/src/main/java/com/clueride/domain/game/ssevent/SSEventServiceImpl.java
@@ -17,6 +17,17 @@
  */
 package com.clueride.domain.game.ssevent;
 
+import com.clueride.auth.session.ClueRideSession;
+import com.clueride.auth.session.ClueRideSessionDto;
+import com.clueride.config.ConfigService;
+import com.clueride.domain.game.GameState;
+import com.clueride.domain.puzzle.answer.AnswerSummary;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,19 +35,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import javax.enterprise.context.SessionScoped;
-import javax.inject.Inject;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-
-import com.clueride.auth.session.ClueRideSession;
-import com.clueride.auth.session.ClueRideSessionDto;
-import com.clueride.config.ConfigService;
-import com.clueride.domain.game.GameState;
-import com.clueride.domain.puzzle.answer.AnswerSummary;
 
 
 /**
@@ -98,7 +96,7 @@ public class SSEventServiceImpl implements SSEventService {
     private String answerSummaryEventMessage(AnswerSummary answerSummary) {
         AnswerSummaryEvent answerSummaryEvent = new AnswerSummaryEvent(
                 SSEventType.ANSWER_SUMMARY.toString(),
-                clueRideSessionDto.getOutingView().getId(),
+                clueRideSessionDto.getOutingId(),
                 answerSummary
         );
         try {
@@ -114,7 +112,7 @@ public class SSEventServiceImpl implements SSEventService {
         SSEventMessage ssEventMessage =
                 new SSEventMessage(
                         event,
-                        clueRideSessionDto.getOutingView().getId(),
+                        clueRideSessionDto.getOutingId(),
                         gameState
                 );
         try {
@@ -184,7 +182,7 @@ public class SSEventServiceImpl implements SSEventService {
                 "http://" + sseHost
                         + "/rest/"
                         + endpoint + "/"
-                        + clueRideSessionDto.getOutingView().getId()
+                        + clueRideSessionDto.getOutingId()
         );
     }
 

--- a/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
+++ b/src/main/java/com/clueride/domain/location/LocationServiceImpl.java
@@ -28,6 +28,7 @@ import com.clueride.domain.location.latlon.LatLonService;
 import com.clueride.domain.location.loclink.LocLink;
 import com.clueride.domain.location.loclink.LocLinkEntity;
 import com.clueride.domain.location.loclink.LocLinkService;
+import com.clueride.domain.outing.OutingService;
 import com.clueride.domain.outing.OutingView;
 import com.clueride.domain.place.ScoredLocationService;
 import com.clueride.domain.puzzle.PuzzleService;
@@ -63,6 +64,7 @@ public class LocationServiceImpl implements LocationService {
     private final ImageStore imageStore;
     private final PuzzleService puzzleService;
     private final LocLinkService locLinkService;
+    private final OutingService outingService;
 
     @Inject
     public LocationServiceImpl(
@@ -72,7 +74,8 @@ public class LocationServiceImpl implements LocationService {
             ScoredLocationService scoredLocationService,
             ImageStore imageStore,
             PuzzleService puzzleService,
-            LocLinkService locLinkService
+            LocLinkService locLinkService,
+            OutingService outingService
     ) {
         this.courseService = courseService;
         this.locationStore = locationStore;
@@ -81,6 +84,7 @@ public class LocationServiceImpl implements LocationService {
         this.imageStore = imageStore;
         this.puzzleService = puzzleService;
         this.locLinkService = locLinkService;
+        this.outingService = outingService;
     }
 
     @Override
@@ -126,7 +130,7 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public List<Location> getSessionLocationsWithGeoJson() {
         List<Location> locations = new ArrayList<>();
-        OutingView outingView = clueRideSessionDto.getOutingView();
+        OutingView outingView = outingService.getViewById(clueRideSessionDto.getOutingId());
         List<Integer> locationIds = courseService.getAttractionIdsForCourse(outingView.getCourseId());
         for (Integer locationId : locationIds) {
             LocationEntity locationEntity = locationStore.getLocationBuilderById(locationId);

--- a/src/main/java/com/clueride/domain/outing/OutingConstants.java
+++ b/src/main/java/com/clueride/domain/outing/OutingConstants.java
@@ -3,4 +3,5 @@ package com.clueride.domain.outing;
 public class OutingConstants {
     /* This needs to be the ID of the Eternal Outing record in the Database. */
     public final static int ETERNAL_OUTING_ID = 1;
+    public static final Integer NO_OUTING = -1;
 }

--- a/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
+++ b/src/main/java/com/clueride/domain/outing/OutingServiceImpl.java
@@ -56,7 +56,7 @@ public class OutingServiceImpl implements OutingService {
         if (clueRideSessionDto.hasNoOuting()) {
             throw new NoSessionOutingException();
         }
-        return clueRideSessionDto.getOutingView();
+        return outingStore.getOutingViewById(clueRideSessionDto.getOutingId()).build();
     }
 
     @Override

--- a/src/test/java/com/clueride/domain/game/GameStateServiceImplTest.java
+++ b/src/test/java/com/clueride/domain/game/GameStateServiceImplTest.java
@@ -3,6 +3,8 @@ package com.clueride.domain.game;
 import com.clueride.auth.session.ClueRideSessionDto;
 import com.clueride.domain.course.Course;
 import com.clueride.domain.course.CourseService;
+import com.clueride.domain.outing.OutingConstants;
+import com.clueride.domain.outing.OutingService;
 import com.clueride.domain.outing.OutingView;
 import org.jglue.cdiunit.NgCdiRunner;
 import org.junit.Before;
@@ -40,6 +42,9 @@ public class GameStateServiceImplTest extends NgCdiRunner {
     @Mock
     private Course mockCourse;
 
+    @Mock
+    private OutingService outingService;
+
     @Before
     public void setup() {
         initMocks(this);
@@ -58,7 +63,7 @@ public class GameStateServiceImplTest extends NgCdiRunner {
 
         /* Train Mocks */
         when(outingView.getCourseId()).thenReturn(TEST_COURSE_ID);
-        when(clueRideSessionDto.getOutingView()).thenReturn(outingView);
+        when(clueRideSessionDto.getOutingId()).thenReturn(OutingConstants.ETERNAL_OUTING_ID);
         when(courseService.getById(TEST_COURSE_ID)).thenReturn(mockCourse);
         when(mockCourse.getLocationIds()).thenReturn(FULL_SET_ATTRACTION_IDS);
 
@@ -77,9 +82,10 @@ public class GameStateServiceImplTest extends NgCdiRunner {
 
         /* Train Mocks */
         when(outingView.getCourseId()).thenReturn(TEST_COURSE_ID);
-        when(clueRideSessionDto.getOutingView()).thenReturn(outingView);
+        when(clueRideSessionDto.getOutingId()).thenReturn(OutingConstants.ETERNAL_OUTING_ID);
         when(courseService.getById(TEST_COURSE_ID)).thenReturn(mockCourse);
         when(mockCourse.getLocationIds()).thenReturn(FULL_SET_ATTRACTION_IDS);
+        when(outingService.getViewById(OutingConstants.ETERNAL_OUTING_ID)).thenReturn(outingView);
 
         /* Make call */
         boolean actual = toTest.isEndOfCourse(gameStateBuilder);


### PR DESCRIPTION
- Adds Reset endpoint for the GameState which calls the service layer to place
an empty GameState within the Session's GameState Map, keyed by the Outing ID.
- Pulls OutingView from the Session and records just the OutingID permitting the
Outing details to be updated in the DB without having to update any live sessions.